### PR TITLE
:arrow_up: update: upgrade actions/setup-go, configure-pages, upload-…

### DIFF
--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.24
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@latest
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Generate
         run: go generate ./...
@@ -45,7 +45,7 @@ jobs:
       - name: Delete Redundant Files
         run: rm -rf docs/docs.go
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in the `.github/workflows/swagger.yml` file to use the latest versions of various actions. The most important changes include:

Updates to action versions:

* Updated `actions/setup-go` from version 4 to version 5.
* Updated `actions/configure-pages` from version 3 to version 5.
* Updated `actions/upload-pages-artifact` from version 2 to version 3.
* Updated `actions/deploy-pages` from version 2 to version 4.