### PR TITLE
ci: avoid duplicate govulncheck checkout

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           go-version-file: go.mod
           go-package: ./...
+          repo-checkout: false
       - name: Run submodule govulncheck
         run: |
           set -euo pipefail

--- a/aigc/prompts/govulncheck-checkout-fix-2026-06-05.zh-CN.md
+++ b/aigc/prompts/govulncheck-checkout-fix-2026-06-05.zh-CN.md
@@ -1,0 +1,19 @@
+# 2026-06-05 govulncheck checkout 修复记忆
+
+## 现象
+
+Dependabot 创建 `actions/checkout` 升级 PR 后，`govulncheck` 失败在 `golang/govulncheck-action@v1` 内部 checkout 阶段，日志出现 `Duplicate header: "Authorization"`，不是漏洞扫描结果失败。
+
+## 处理
+
+- workflow 已经先执行 `actions/checkout`。
+- 给 root `golang/govulncheck-action@v1` 增加 `repo-checkout: false`，避免 action 内部重复 checkout。
+- submodule govulncheck 仍使用已 checkout 的本地工作区执行。
+
+## 验证
+
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
+
+## 后续
+
+如果同类问题在其他 Go 仓库出现，优先采用外部 checkout + `repo-checkout: false` 的模式。


### PR DESCRIPTION
## Summary
- disable the internal checkout inside golang/govulncheck-action because this workflow already checks out the repository
- avoid Duplicate Authorization header failures seen on Dependabot actions/checkout upgrade PRs
- keep submodule govulncheck on the already checked out workspace
- record the decision in aigc memory

## Tests / 验证
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- git diff --check

## Docs / 文档
- Added aigc/prompts/govulncheck-checkout-fix-2026-06-05.zh-CN.md

## Security / 安全
- Keeps root and submodule govulncheck enabled; this only changes checkout behavior before the scan.

## Release / 发布与回滚
- Affects CI only. Rollback is reverting this PR if govulncheck-action changes its checkout behavior later.