### PR TITLE
ci: upgrade action runtime versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
 
         steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
         - name: Setup golang
-          uses: actions/setup-go@v5
+          uses: actions/setup-go@v6
           with:
             go-version: 1.26
         - name: Start Redis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
             build-mode: autobuild
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run root govulncheck
         uses: golang/govulncheck-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26
       - name: Start Redis

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scorecard-results.sarif

--- a/.github/workflows/swagger.yml
+++ b/.github/workflows/swagger.yml
@@ -28,9 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.26
       - name: Install swag

--- a/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,7 @@
+# Actions runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：后台后端仓库主干流水线已恢复稳定，但 GitHub Actions 继续提示 checkout / CodeQL 相关 action 的 Node 20 runtime 与 CodeQL v3 弃用风险。
+- 处理：将 `actions/checkout` 与 `actions/setup-go` 升级到 `v6`，将 `github/codeql-action/init|analyze|upload-sarif` 升级到 `v4`。
+- 约束：只处理 CI 基础设施，不修改后端业务、部署配置或 beta/prod 环境。
+- 验收：PR checks 全绿后再合并，合并后继续观察 main 的 CI、CodeQL、govulncheck、Scorecard、Mirror、Swagger。


### PR DESCRIPTION
## Summary
- upgrade checkout/setup-go actions to `v6`
- upgrade CodeQL init/analyze/upload-sarif to `v4`
- record the runtime-upgrade context in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified `actions/checkout@v6`, `actions/setup-go@v6`, and `github/codeql-action@v4` tags via GitHub API

## Docs
- Added `aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No backend security behavior changes.
- Keeps CodeQL and SARIF upload actions on the supported major version and moves Go setup to the Node 24-compatible major version.

## Release
- CI-only change; no backend image or beta deployment is triggered by this PR itself.