### PR TITLE
ci: upgrade docker action runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       # https://github.com/docker/login-action
         - name: Log into registry ${{ env.REGISTRY }}
           if: github.event_name != 'pull_request'
-          uses: docker/login-action@v3
+          uses: docker/login-action@v4
           with:
             registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}
@@ -75,18 +75,18 @@ jobs:
 
         - name: Set up QEMU
           if: github.event_name != 'pull_request'
-          uses: docker/setup-qemu-action@v3
+          uses: docker/setup-qemu-action@v4
 
         - name: Set up Docker Buildx
           if: github.event_name != 'pull_request'
-          uses: docker/setup-buildx-action@v3
+          uses: docker/setup-buildx-action@v4
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
         - name: Extract Docker metadata
           id: meta
           if: github.event_name != 'pull_request'
-          uses: docker/metadata-action@v5
+          uses: docker/metadata-action@v6
           with:
             images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}'
             flavor: |
@@ -100,7 +100,7 @@ jobs:
       # https://github.com/docker/build-push-action
         - name: Build and push Docker image
           if: github.event_name != 'pull_request'
-          uses: docker/build-push-action@v5
+          uses: docker/build-push-action@v7
           with:
             context: .
             file: Dockerfile

--- a/aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,8 @@
+# Docker action runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：mss-boot-admin 主干 CI 已全绿，但 Docker image build/push 阶段提示 `docker/login-action@v3`、`docker/setup-qemu-action@v3`、`docker/setup-buildx-action@v3`、`docker/metadata-action@v5`、`docker/build-push-action@v5` 仍使用 Node.js 20 runtime。
+- 处理：升级 Docker 官方 actions 到 node24 major：login/setup-qemu/setup-buildx 使用 `v4`，metadata 使用 `v6`，build-push 使用 `v7`。
+- 约束：保持现有镜像构建、tag、push 逻辑不变，只升级 action runtime。
+- 验收：PR checks 与 main CI 验证 Docker image build/push 成功，确认不再出现 Docker actions 的 Node20 runtime 注解。
+


### PR DESCRIPTION
## Summary
- upgrade Docker official actions to their Node 24-compatible major versions
- keep the existing image tag/build/push behavior unchanged
- record the runtime follow-up in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified Docker action latest releases use `node24` via GitHub API

## Docs
- Added `aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No backend security behavior changes.
- Removes Docker action Node.js 20 runtime warnings from the image build/push path.

## Release
- CI-only action runtime change; image build/push logic is unchanged.
