### PR TITLE
ci: quiet qemu cache warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         - name: Set up QEMU
           if: github.event_name != 'pull_request'
           uses: docker/setup-qemu-action@v4
+          with:
+            cache-image: false
 
         - name: Set up Docker Buildx
           if: github.event_name != 'pull_request'

--- a/aigc/prompts/qemu-cache-noise-2026-06-05.zh-CN.md
+++ b/aigc/prompts/qemu-cache-noise-2026-06-05.zh-CN.md
@@ -1,0 +1,8 @@
+# QEMU cache 噪声治理记忆
+
+- 日期：2026-06-05
+- 背景：Docker actions 升级到 node24 major 后，mss-boot-admin 主干 CI 已成功且不再出现 Node20 runtime 注解，但 `docker/setup-qemu-action@v4` 在并发场景下可能提示无法保存 `tonistiigi/binfmt` cache。
+- 处理：在主干 Docker build/push 路径中设置 `cache-image: false`，避免 GitHub Actions cache key 并发占用造成的非阻断 warning。
+- 取舍：可能牺牲少量 QEMU 初始化速度，但换取更安静稳定的开源流水线体验。
+- 验收：PR 与 main CI 均需确认 image build/push 成功，且不再出现 QEMU cache save warning。
+


### PR DESCRIPTION
## Summary
- disable `docker/setup-qemu-action` image caching on the non-PR Docker build path
- avoid non-blocking cache reservation warnings when concurrent jobs touch the same binfmt cache key
- record the noise-reduction context in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified `docker/setup-qemu-action@v4` supports `cache-image`

## Docs
- Added `aigc/prompts/qemu-cache-noise-2026-06-05.zh-CN.md`.

## Security
- No backend security behavior changes.
- Keeps the Docker build path on node24-compatible actions.

## Release
- CI-only noise-reduction change; image build/push behavior is unchanged except QEMU image cache is disabled.
