### PR TITLE
ci: add Copilot setup steps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
     labels:
       - "area/backend"
       - "type/security"
@@ -16,6 +17,7 @@ updates:
     directory: "/cmd/tools/pr"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     labels:
       - "area/devops"
       - "type/security"
@@ -23,6 +25,7 @@ updates:
     directory: "/compose/consul"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     labels:
       - "area/devops"
       - "type/security"
@@ -30,6 +33,7 @@ updates:
     directory: "/compose/kafka"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
     labels:
       - "area/devops"
       - "type/security"
@@ -37,6 +41,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "area/devops"
       - "type/security"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,28 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Download Go modules
+        run: go mod download

--- a/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
+++ b/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
@@ -1,0 +1,20 @@
+# GitHub Copilot Setup Steps
+
+日期：2026-06-05
+
+## 背景
+
+`mss-boot-admin` 后端可以较频繁发布到 beta 环境，适合把低风险、可验证的
+修复任务逐步交给 GitHub Copilot coding agent 处理。
+
+## 已落地
+
+- 新增 `.github/workflows/copilot-setup-steps.yml`。
+- 工作流只在手动触发、或该 workflow 文件变更时运行。
+- 代理环境步骤包括 checkout、`actions/setup-go@v6` 和 `go mod download`。
+
+## 约束
+
+- 该 workflow 只做环境预热，不自动发布镜像。
+- 后端镜像发布仍由现有 CI/release 流程控制。
+- 数据库、Redis、beta/prod 环境变更必须通过已有部署记忆和发布流程确认。


### PR DESCRIPTION
## Summary
- add .github/workflows/copilot-setup-steps.yml so GitHub Copilot coding agent can prewarm Go dependencies
- add explicit Dependabot PR limits and grouped GitHub Actions updates
- record repository-local AIGC memory for the GitHub handoff

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'\n- git diff --check\n\n## Docs\n- Adds repository-local AIGC memory under aigc/prompts/.\n\n## Security\n- Keeps the Copilot setup workflow read-only with contents: read.\n- Dependabot grouping only changes version update batching; security alerts remain reviewed through GitHub.\n\n## Release / compatibility / rollback\n- No backend image release impact.\n- Existing CI/release workflows remain the publish path.\n- Rollback is reverting the setup workflow and Dependabot grouping if they add noise.\n\n## Notes\n- The setup workflow does not publish backend images.