### PR TITLE
fix: remove unused audit response wrapper

### DIFF
--- a/middleware/audit.go
+++ b/middleware/audit.go
@@ -15,16 +15,6 @@ import (
 	"github.com/mss-boot-io/mss-boot/pkg/response"
 )
 
-type responseWriter struct {
-	gin.ResponseWriter
-	body *bytes.Buffer
-}
-
-func (w *responseWriter) Write(b []byte) (int, error) {
-	w.body.Write(b)
-	return w.ResponseWriter.Write(b)
-}
-
 func AuditLogMiddleware(skipPaths ...string) gin.HandlerFunc {
 	skipMap := make(map[string]bool)
 	for _, path := range skipPaths {
@@ -33,9 +23,6 @@ func AuditLogMiddleware(skipPaths ...string) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		start := time.Now()
-
-		blw := &responseWriter{body: bytes.NewBufferString(""), ResponseWriter: c.Writer}
-		c.Writer = blw
 
 		var requestBody string
 		if c.Request.Body != nil && c.Request.Method != http.MethodGet {


### PR DESCRIPTION
## Summary

- Remove the unused audit middleware response writer wrapper.
- Keep request body capture and audit log behavior unchanged.

## Tests / Verification

- Ran ?   	github.com/mss-boot-io/mss-boot-admin/middleware	[no test files]
ok  	github.com/mss-boot-io/mss-boot-admin/service	(cached).

## Docs Impact

- No docs change needed; behavior and public API remain unchanged.

## Security Impact

- Removes an unnecessary response interception layer and reduces reflected write-back surface flagged during security review.

## Release Impact

- No migration, config, image, compatibility, or rollback impact expected.