### PR TITLE
fix: clean generated menus after model delete

### DIFF
--- a/aigc/prompts/model-delete-menu-cleanup-2026-06-07.zh-CN.md
+++ b/aigc/prompts/model-delete-menu-cleanup-2026-06-07.zh-CN.md
@@ -16,7 +16,13 @@
 - 清理范围只覆盖模型生成的 `/virtual/<model.path>` 根菜单及其子节点。
 - 如果仍有其他 active 模型使用相同 `path`，不清理该菜单树，避免误删共享 path 的
   仍在用菜单。
-- 同步删除这些菜单/API 路径对应的 Casbin policy，并重新加载 policy。
+- 只清理 `generated_data=true` 的模型对应菜单，避免模型未生成数据时误删用户手工菜单。
+- 根菜单必须是 `MenuAccessType`，避免相同 path 的非菜单节点被当作生成菜单树根。
+- 菜单软删除和 Casbin policy 删除必须在同一 DB transaction 中完成。
+- 同步精确删除这些菜单/API 路径对应的 Casbin policy；匹配条件使用
+  `ptype + v1(type) + v2(path) + v3(method)`，避免仅按 path 误删复用 policy。
+- 事务提交后重新加载 policy；`LoadPolicy` 失败只记录 warning，不把已完成的数据清理
+  上报为接口 500。
 - 不处理无关菜单，避免误删用户手动维护的其他菜单。
 
 ## 本轮变更
@@ -25,17 +31,22 @@
   - 为模型 controller 增加 `WithAfterDelete(deleteGeneratedModelMenus)`。
   - 根据通用 Delete action 写入的 `ids` 找到已删除模型。
   - 递归软删除 `/virtual/<path>` 菜单树。
-  - 删除关联 Casbin policy。
+  - 删除关联 Casbin policy，并保护同 path active 模型和未生成数据的手工菜单。
 - `apis/model_test.go`
   - 覆盖模型删除后生成菜单树被软删除。
   - 覆盖关联 policy 被清理。
   - 覆盖无关菜单和 policy 不受影响。
   - 覆盖仍有 active 模型使用相同 path 时不清理菜单和 policy。
+  - 覆盖 policy 删除失败时菜单软删除回滚。
+  - 覆盖 `LoadPolicy` 失败时不阻断已完成清理。
+  - 覆盖同 path 但 type/method 不同的 policy 不被误删。
+  - 覆盖 `generated_data=false` 时手工菜单和 policy 不被误删。
 
 ## 验证
 
 ```text
 go test ./apis
+go test ./apis ./models ./middleware
 ```
 
 ## 后续

--- a/aigc/prompts/model-delete-menu-cleanup-2026-06-07.zh-CN.md
+++ b/aigc/prompts/model-delete-menu-cleanup-2026-06-07.zh-CN.md
@@ -1,0 +1,44 @@
+# Model Delete Menu Cleanup
+
+日期：2026-06-07
+
+## 背景
+
+外部 issue `#75` 反馈：模型列表删除后，首页 MenuBar 中仍然保留对应菜单，
+点击后会报错，需要手动删除菜单。
+
+当前模型生成数据时会创建 `/virtual/<model.path>` 菜单树及其 API/组件子节点；
+但模型删除走通用 GORM Delete action，没有同步清理生成菜单和 Casbin policy。
+
+## 决策
+
+- 模型删除后清理该模型生成的菜单树，而不是要求用户手动删除菜单。
+- 清理范围只覆盖模型生成的 `/virtual/<model.path>` 根菜单及其子节点。
+- 如果仍有其他 active 模型使用相同 `path`，不清理该菜单树，避免误删共享 path 的
+  仍在用菜单。
+- 同步删除这些菜单/API 路径对应的 Casbin policy，并重新加载 policy。
+- 不处理无关菜单，避免误删用户手动维护的其他菜单。
+
+## 本轮变更
+
+- `apis/model.go`
+  - 为模型 controller 增加 `WithAfterDelete(deleteGeneratedModelMenus)`。
+  - 根据通用 Delete action 写入的 `ids` 找到已删除模型。
+  - 递归软删除 `/virtual/<path>` 菜单树。
+  - 删除关联 Casbin policy。
+- `apis/model_test.go`
+  - 覆盖模型删除后生成菜单树被软删除。
+  - 覆盖关联 policy 被清理。
+  - 覆盖无关菜单和 policy 不受影响。
+  - 覆盖仍有 active 模型使用相同 path 时不清理菜单和 policy。
+
+## 验证
+
+```text
+go test ./apis
+```
+
+## 后续
+
+- `#75` 仍包含多个未拆分问题；本轮只处理其中“模型删除后菜单残留”这个可确认子问题。
+- 其他子问题仍需要基于当前 main 或最新 release 补充复现步骤、接口响应和前端截图。

--- a/apis/model.go
+++ b/apis/model.go
@@ -4,16 +4,19 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/mss-boot-io/mss-boot-admin/center"
 
 	adminPKG "github.com/mss-boot-io/mss-boot-admin/pkg"
 
 	"github.com/gin-gonic/gin"
+	"github.com/mss-boot-io/mss-boot/pkg/config/gormdb"
 	"github.com/mss-boot-io/mss-boot/pkg/response"
 	"github.com/mss-boot-io/mss-boot/pkg/response/actions"
 	"github.com/mss-boot-io/mss-boot/pkg/response/controller"
 	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
 
 	"github.com/mss-boot-io/mss-boot-admin/dto"
 	"github.com/mss-boot-io/mss-boot-admin/models"
@@ -33,6 +36,7 @@ func init() {
 			controller.WithModel(new(models.Model)),
 			controller.WithSearch(new(dto.ModelSearch)),
 			controller.WithModelProvider(actions.ModelProviderGorm),
+			controller.WithAfterDelete(deleteGeneratedModelMenus),
 		),
 	}
 	response.AppendController(e)
@@ -315,6 +319,159 @@ func (e *Model) i18n(api *response.API, tx *gorm.DB, m *models.Model, req *dto.M
 		return err
 	}
 	return nil
+}
+
+type generatedMenuPolicyTarget struct {
+	ID     string
+	Path   string
+	Method string
+	Type   adminPKG.AccessType
+}
+
+func deleteGeneratedModelMenus(ctx *gin.Context, db *gorm.DB, _ schema.Tabler) error {
+	idsValue, ok := ctx.Get("ids")
+	if !ok {
+		return nil
+	}
+	modelIDs, ok := idsValue.([]string)
+	if !ok || len(modelIDs) == 0 {
+		return nil
+	}
+
+	modelsToClean := make([]*models.Model, 0, len(modelIDs))
+	if err := db.Unscoped().Where("id IN ?", modelIDs).Find(&modelsToClean).Error; err != nil {
+		return err
+	}
+
+	rootPaths, err := generatedMenuRootPaths(db, modelsToClean)
+	if err != nil {
+		return err
+	}
+	if len(rootPaths) == 0 {
+		return nil
+	}
+
+	rootIDs := make([]string, 0, len(rootPaths))
+	if err := db.Model(&models.Menu{}).Where("path IN ?", rootPaths).Pluck("id", &rootIDs).Error; err != nil {
+		return err
+	}
+	if len(rootIDs) == 0 {
+		return nil
+	}
+
+	menuTargets, err := collectGeneratedMenuHierarchy(db, rootIDs)
+	if err != nil {
+		return err
+	}
+	if err := softDeleteGeneratedMenuHierarchy(db, rootIDs); err != nil {
+		return err
+	}
+	if err := deleteGeneratedMenuPolicies(db, menuTargets); err != nil {
+		return err
+	}
+	if gormdb.Enforcer != nil {
+		return gormdb.Enforcer.LoadPolicy()
+	}
+	return nil
+}
+
+func generatedMenuRootPaths(db *gorm.DB, modelsToClean []*models.Model) ([]string, error) {
+	modelPaths := make([]string, 0, len(modelsToClean))
+	seenModelPaths := make(map[string]struct{}, len(modelsToClean))
+	for i := range modelsToClean {
+		if modelsToClean[i].Path == "" {
+			continue
+		}
+		if _, ok := seenModelPaths[modelsToClean[i].Path]; ok {
+			continue
+		}
+		seenModelPaths[modelsToClean[i].Path] = struct{}{}
+		modelPaths = append(modelPaths, modelsToClean[i].Path)
+	}
+	if len(modelPaths) == 0 {
+		return nil, nil
+	}
+
+	activePaths := make([]string, 0)
+	if err := db.Model(&models.Model{}).Where("path IN ?", modelPaths).Pluck("path", &activePaths).Error; err != nil {
+		return nil, err
+	}
+	activePathSet := make(map[string]struct{}, len(activePaths))
+	for i := range activePaths {
+		activePathSet[activePaths[i]] = struct{}{}
+	}
+
+	paths := make([]string, 0, len(modelsToClean))
+	seen := make(map[string]struct{}, len(modelsToClean))
+	for i := range modelsToClean {
+		if modelsToClean[i].Path == "" {
+			continue
+		}
+		if _, ok := activePathSet[modelsToClean[i].Path]; ok {
+			continue
+		}
+		path := "/virtual/" + modelsToClean[i].Path
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+func collectGeneratedMenuHierarchy(db *gorm.DB, rootIDs []string) ([]generatedMenuPolicyTarget, error) {
+	rows := make([]generatedMenuPolicyTarget, 0)
+	menu := &models.Menu{}
+	sqlTemp := fmt.Sprintf(`WITH RECURSIVE MenuHierarchy AS (
+    SELECT id, path, method, type
+    FROM %s
+    WHERE id IN ? AND deleted_at IS NULL
+    UNION ALL
+    SELECT m.id, m.path, m.method, m.type
+    FROM %s m
+    INNER JOIN MenuHierarchy mh ON m.parent_id = mh.id
+    WHERE m.deleted_at IS NULL
+)
+SELECT id, path, method, type FROM MenuHierarchy`, menu.TableName(), menu.TableName())
+	return rows, db.Raw(sqlTemp, rootIDs).Scan(&rows).Error
+}
+
+func softDeleteGeneratedMenuHierarchy(db *gorm.DB, rootIDs []string) error {
+	menu := &models.Menu{}
+	sqlTemp := fmt.Sprintf(`WITH RECURSIVE MenuHierarchy AS (
+    SELECT id
+    FROM %s
+    WHERE id IN ? AND deleted_at IS NULL
+    UNION ALL
+    SELECT m.id
+    FROM %s m
+    INNER JOIN MenuHierarchy mh ON m.parent_id = mh.id
+    WHERE m.deleted_at IS NULL
+)
+UPDATE %s
+SET deleted_at = ?
+WHERE id IN (SELECT id FROM MenuHierarchy)`, menu.TableName(), menu.TableName(), menu.TableName())
+	return db.Exec(sqlTemp, rootIDs, time.Now()).Error
+}
+
+func deleteGeneratedMenuPolicies(db *gorm.DB, menuTargets []generatedMenuPolicyTarget) error {
+	paths := make([]string, 0, len(menuTargets))
+	seen := make(map[string]struct{}, len(menuTargets))
+	for i := range menuTargets {
+		if menuTargets[i].Path == "" {
+			continue
+		}
+		if _, ok := seen[menuTargets[i].Path]; ok {
+			continue
+		}
+		seen[menuTargets[i].Path] = struct{}{}
+		paths = append(paths, menuTargets[i].Path)
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	return db.Where("ptype = ? AND v2 IN ?", "p", paths).Delete(&models.CasbinRule{}).Error
 }
 
 // Create 创建模型

--- a/apis/model.go
+++ b/apis/model.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mss-boot-io/mss-boot/pkg/response/actions"
 	"github.com/mss-boot-io/mss-boot/pkg/response/controller"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/schema"
 
 	"github.com/mss-boot-io/mss-boot-admin/dto"
@@ -329,22 +330,32 @@ type generatedMenuPolicyTarget struct {
 	Type   adminPKG.AccessType
 }
 
+type generatedModelMenuCleanup struct {
+	MenuTargets []generatedMenuPolicyTarget
+	PolicyRules []models.CasbinRule
+}
+
 func deleteGeneratedModelMenus(ctx *gin.Context, db *gorm.DB, _ schema.Tabler) error {
 	idsValue, ok := ctx.Get("ids")
 	if !ok {
+		slog.Warn("deleteGeneratedModelMenus skipped: ids not in context")
 		return nil
 	}
 	modelIDs, ok := idsValue.([]string)
-	if !ok || len(modelIDs) == 0 {
+	if !ok {
+		slog.Warn("deleteGeneratedModelMenus skipped: ids has unexpected type", "type", fmt.Sprintf("%T", idsValue))
+		return nil
+	}
+	if len(modelIDs) == 0 {
 		return nil
 	}
 
 	modelsToClean := make([]*models.Model, 0, len(modelIDs))
 	if err := db.Unscoped().Where("id IN ?", modelIDs).Find(&modelsToClean).Error; err != nil {
-		return err
+		return restoreDeletedModelsAfterCleanupError(db, modelIDs, err)
 	}
 
-	changed := false
+	var cleanup generatedModelMenuCleanup
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		rootPaths, err := generatedMenuRootPaths(tx, modelsToClean)
 		if err != nil {
@@ -368,20 +379,32 @@ func deleteGeneratedModelMenus(ctx *gin.Context, db *gorm.DB, _ schema.Tabler) e
 		if err != nil {
 			return err
 		}
+		policyRules, err := collectGeneratedMenuPolicies(tx, menuTargets)
+		if err != nil {
+			return err
+		}
 		if err := softDeleteGeneratedMenuHierarchy(tx, rootIDs); err != nil {
 			return err
 		}
 		if err := deleteGeneratedMenuPolicies(tx, menuTargets); err != nil {
 			return err
 		}
-		changed = true
+		cleanup = generatedModelMenuCleanup{
+			MenuTargets: menuTargets,
+			PolicyRules: policyRules,
+		}
 		return nil
 	}); err != nil {
-		return err
+		return restoreDeletedModelsAfterCleanupError(db, modelIDs, err)
 	}
-	if changed && gormdb.Enforcer != nil {
+	if len(cleanup.MenuTargets) > 0 && gormdb.Enforcer != nil {
 		if err := gormdb.Enforcer.LoadPolicy(); err != nil {
-			slog.Warn("reload casbin policy failed after model menu cleanup", "err", err)
+			slog.Error("reload casbin policy failed after model menu cleanup; restoring model/menu/policy state", "err", err)
+			if restoreErr := restoreGeneratedModelMenuCleanup(db, modelIDs, cleanup); restoreErr != nil {
+				slog.Error("restore model menu cleanup failed", "err", restoreErr)
+				return errors.Join(err, restoreErr)
+			}
+			return err
 		}
 	}
 	return nil
@@ -449,6 +472,14 @@ SELECT id, path, method, type FROM MenuHierarchy`, menu.TableName(), menu.TableN
 	return rows, db.Raw(sqlTemp, rootIDs).Scan(&rows).Error
 }
 
+func generatedMenuTargetKey(target generatedMenuPolicyTarget) string {
+	method := target.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+	return fmt.Sprintf("%s|%s|%s", target.Type.String(), target.Path, method)
+}
+
 func softDeleteGeneratedMenuHierarchy(db *gorm.DB, rootIDs []string) error {
 	menu := &models.Menu{}
 	sqlTemp := fmt.Sprintf(`WITH RECURSIVE MenuHierarchy AS (
@@ -467,21 +498,52 @@ WHERE id IN (SELECT id FROM MenuHierarchy)`, menu.TableName(), menu.TableName(),
 	return db.Exec(sqlTemp, rootIDs, time.Now()).Error
 }
 
+func collectGeneratedMenuPolicies(db *gorm.DB, menuTargets []generatedMenuPolicyTarget) ([]models.CasbinRule, error) {
+	rules := make([]models.CasbinRule, 0)
+	seen := make(map[string]struct{}, len(menuTargets))
+	for i := range menuTargets {
+		if menuTargets[i].Path == "" {
+			continue
+		}
+		key := generatedMenuTargetKey(menuTargets[i])
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		method := menuTargets[i].Method
+		if method == "" {
+			method = http.MethodGet
+		}
+		var targetRules []models.CasbinRule
+		if err := db.Where("ptype = ? AND v1 = ? AND v2 = ? AND v3 = ?",
+			"p", menuTargets[i].Type.String(), menuTargets[i].Path, method).
+			Find(&targetRules).Error; err != nil {
+			return nil, err
+		}
+		rules = append(rules, targetRules...)
+	}
+	if len(rules) > 0 {
+		slog.Info("collected generated menu policies for cleanup", "count", len(rules))
+	}
+	return rules, nil
+}
+
 func deleteGeneratedMenuPolicies(db *gorm.DB, menuTargets []generatedMenuPolicyTarget) error {
 	seen := make(map[string]struct{}, len(menuTargets))
 	for i := range menuTargets {
 		if menuTargets[i].Path == "" {
 			continue
 		}
-		method := menuTargets[i].Method
-		if method == "" {
-			method = http.MethodGet
-		}
-		key := fmt.Sprintf("%s|%s|%s", menuTargets[i].Type.String(), menuTargets[i].Path, method)
+		key := generatedMenuTargetKey(menuTargets[i])
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
+		method := menuTargets[i].Method
+		if method == "" {
+			method = http.MethodGet
+		}
 		if err := db.Where("ptype = ? AND v1 = ? AND v2 = ? AND v3 = ?",
 			"p", menuTargets[i].Type.String(), menuTargets[i].Path, method).
 			Delete(&models.CasbinRule{}).Error; err != nil {
@@ -489,6 +551,61 @@ func deleteGeneratedMenuPolicies(db *gorm.DB, menuTargets []generatedMenuPolicyT
 		}
 	}
 	return nil
+}
+
+func restoreDeletedModelsAfterCleanupError(db *gorm.DB, modelIDs []string, cause error) error {
+	if err := restoreDeletedModels(db, modelIDs); err != nil {
+		slog.Error("failed to restore model after generated menu cleanup error",
+			"modelIDs", modelIDs, "cleanupErr", cause, "restoreErr", err)
+		return errors.Join(cause, err)
+	}
+	slog.Warn("restored model after generated menu cleanup error", "modelIDs", modelIDs, "err", cause)
+	return cause
+}
+
+func restoreGeneratedModelMenuCleanup(db *gorm.DB, modelIDs []string, cleanup generatedModelMenuCleanup) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := restoreDeletedModels(tx, modelIDs); err != nil {
+			return err
+		}
+
+		menuIDs := make([]string, 0, len(cleanup.MenuTargets))
+		seenMenuIDs := make(map[string]struct{}, len(cleanup.MenuTargets))
+		for i := range cleanup.MenuTargets {
+			if cleanup.MenuTargets[i].ID == "" {
+				continue
+			}
+			if _, ok := seenMenuIDs[cleanup.MenuTargets[i].ID]; ok {
+				continue
+			}
+			seenMenuIDs[cleanup.MenuTargets[i].ID] = struct{}{}
+			menuIDs = append(menuIDs, cleanup.MenuTargets[i].ID)
+		}
+		if len(menuIDs) > 0 {
+			if err := tx.Unscoped().Model(&models.Menu{}).
+				Where("id IN ?", menuIDs).
+				Update("deleted_at", nil).Error; err != nil {
+				return err
+			}
+		}
+
+		if len(cleanup.PolicyRules) > 0 {
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).
+				Create(&cleanup.PolicyRules).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func restoreDeletedModels(db *gorm.DB, modelIDs []string) error {
+	if len(modelIDs) == 0 {
+		return nil
+	}
+	return db.Unscoped().Model(&models.Model{}).
+		Where("id IN ?", modelIDs).
+		Update("deleted_at", nil).Error
 }
 
 // Create 创建模型

--- a/apis/model.go
+++ b/apis/model.go
@@ -3,6 +3,7 @@ package apis
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -343,34 +344,45 @@ func deleteGeneratedModelMenus(ctx *gin.Context, db *gorm.DB, _ schema.Tabler) e
 		return err
 	}
 
-	rootPaths, err := generatedMenuRootPaths(db, modelsToClean)
-	if err != nil {
-		return err
-	}
-	if len(rootPaths) == 0 {
-		return nil
-	}
+	changed := false
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		rootPaths, err := generatedMenuRootPaths(tx, modelsToClean)
+		if err != nil {
+			return err
+		}
+		if len(rootPaths) == 0 {
+			return nil
+		}
 
-	rootIDs := make([]string, 0, len(rootPaths))
-	if err := db.Model(&models.Menu{}).Where("path IN ?", rootPaths).Pluck("id", &rootIDs).Error; err != nil {
-		return err
-	}
-	if len(rootIDs) == 0 {
-		return nil
-	}
+		rootIDs := make([]string, 0, len(rootPaths))
+		if err := tx.Model(&models.Menu{}).
+			Where("type = ? AND path IN ?", adminPKG.MenuAccessType, rootPaths).
+			Pluck("id", &rootIDs).Error; err != nil {
+			return err
+		}
+		if len(rootIDs) == 0 {
+			return nil
+		}
 
-	menuTargets, err := collectGeneratedMenuHierarchy(db, rootIDs)
-	if err != nil {
+		menuTargets, err := collectGeneratedMenuHierarchy(tx, rootIDs)
+		if err != nil {
+			return err
+		}
+		if err := softDeleteGeneratedMenuHierarchy(tx, rootIDs); err != nil {
+			return err
+		}
+		if err := deleteGeneratedMenuPolicies(tx, menuTargets); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	}); err != nil {
 		return err
 	}
-	if err := softDeleteGeneratedMenuHierarchy(db, rootIDs); err != nil {
-		return err
-	}
-	if err := deleteGeneratedMenuPolicies(db, menuTargets); err != nil {
-		return err
-	}
-	if gormdb.Enforcer != nil {
-		return gormdb.Enforcer.LoadPolicy()
+	if changed && gormdb.Enforcer != nil {
+		if err := gormdb.Enforcer.LoadPolicy(); err != nil {
+			slog.Warn("reload casbin policy failed after model menu cleanup", "err", err)
+		}
 	}
 	return nil
 }
@@ -379,7 +391,7 @@ func generatedMenuRootPaths(db *gorm.DB, modelsToClean []*models.Model) ([]strin
 	modelPaths := make([]string, 0, len(modelsToClean))
 	seenModelPaths := make(map[string]struct{}, len(modelsToClean))
 	for i := range modelsToClean {
-		if modelsToClean[i].Path == "" {
+		if !modelsToClean[i].GeneratedData || modelsToClean[i].Path == "" {
 			continue
 		}
 		if _, ok := seenModelPaths[modelsToClean[i].Path]; ok {
@@ -404,7 +416,7 @@ func generatedMenuRootPaths(db *gorm.DB, modelsToClean []*models.Model) ([]strin
 	paths := make([]string, 0, len(modelsToClean))
 	seen := make(map[string]struct{}, len(modelsToClean))
 	for i := range modelsToClean {
-		if modelsToClean[i].Path == "" {
+		if !modelsToClean[i].GeneratedData || modelsToClean[i].Path == "" {
 			continue
 		}
 		if _, ok := activePathSet[modelsToClean[i].Path]; ok {
@@ -456,22 +468,27 @@ WHERE id IN (SELECT id FROM MenuHierarchy)`, menu.TableName(), menu.TableName(),
 }
 
 func deleteGeneratedMenuPolicies(db *gorm.DB, menuTargets []generatedMenuPolicyTarget) error {
-	paths := make([]string, 0, len(menuTargets))
 	seen := make(map[string]struct{}, len(menuTargets))
 	for i := range menuTargets {
 		if menuTargets[i].Path == "" {
 			continue
 		}
-		if _, ok := seen[menuTargets[i].Path]; ok {
+		method := menuTargets[i].Method
+		if method == "" {
+			method = http.MethodGet
+		}
+		key := fmt.Sprintf("%s|%s|%s", menuTargets[i].Type.String(), menuTargets[i].Path, method)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		seen[menuTargets[i].Path] = struct{}{}
-		paths = append(paths, menuTargets[i].Path)
+		seen[key] = struct{}{}
+		if err := db.Where("ptype = ? AND v1 = ? AND v2 = ? AND v3 = ?",
+			"p", menuTargets[i].Type.String(), menuTargets[i].Path, method).
+			Delete(&models.CasbinRule{}).Error; err != nil {
+			return err
+		}
 	}
-	if len(paths) == 0 {
-		return nil
-	}
-	return db.Where("ptype = ? AND v2 IN ?", "p", paths).Delete(&models.CasbinRule{}).Error
+	return nil
 }
 
 // Create 创建模型

--- a/apis/model_test.go
+++ b/apis/model_test.go
@@ -281,9 +281,17 @@ func TestDeleteGeneratedModelMenusRollsBackMenuSoftDeleteWhenPolicyDeleteFails(t
 	if activeMenus != 1 {
 		t.Fatalf("expected menu soft delete to roll back, got %d active menus", activeMenus)
 	}
+
+	var activeModels int64
+	if err := db.Model(&models.Model{}).Where("id = ?", model.ID).Count(&activeModels).Error; err != nil {
+		t.Fatalf("count active model: %v", err)
+	}
+	if activeModels != 1 {
+		t.Fatalf("expected model delete to be restored after cleanup failure, got %d active models", activeModels)
+	}
 }
 
-func TestDeleteGeneratedModelMenusIgnoresLoadPolicyFailureAfterCleanup(t *testing.T) {
+func TestDeleteGeneratedModelMenusRestoresStateWhenLoadPolicyFails(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:model-menu-load-policy-fail?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -335,23 +343,31 @@ m = r.sub == p.sub && r.tp == p.tp && keyMatch(r.obj, p.obj) && regexMatch(r.act
 	ctx, _ := gin.CreateTestContext(nil)
 	ctx.Set("ids", []string{model.ID})
 
-	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err != nil {
-		t.Fatalf("delete generated menus: %v", err)
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err == nil {
+		t.Fatalf("expected load policy error")
 	}
 
-	var deletedMenus int64
-	if err := db.Unscoped().Model(&models.Menu{}).Where("id = ? AND deleted_at IS NOT NULL", menu.ID).Count(&deletedMenus).Error; err != nil {
-		t.Fatalf("count deleted menu: %v", err)
+	var activeModels int64
+	if err := db.Model(&models.Model{}).Where("id = ?", model.ID).Count(&activeModels).Error; err != nil {
+		t.Fatalf("count active model: %v", err)
 	}
-	if deletedMenus != 1 {
-		t.Fatalf("expected menu to be soft deleted, got %d", deletedMenus)
+	if activeModels != 1 {
+		t.Fatalf("expected model delete to be restored after load policy failure, got %d active models", activeModels)
+	}
+
+	var activeMenus int64
+	if err := db.Model(&models.Menu{}).Where("id = ?", menu.ID).Count(&activeMenus).Error; err != nil {
+		t.Fatalf("count active menu: %v", err)
+	}
+	if activeMenus != 1 {
+		t.Fatalf("expected menu to be restored after load policy failure, got %d active menus", activeMenus)
 	}
 
 	var rules int64
 	if err := db.Model(&models.CasbinRule{}).Where("id = ?", rule.ID).Count(&rules).Error; err != nil {
 		t.Fatalf("count rule: %v", err)
 	}
-	if rules != 0 {
-		t.Fatalf("expected policy to be deleted, got %d", rules)
+	if rules != 1 {
+		t.Fatalf("expected policy to be restored after load policy failure, got %d", rules)
 	}
 }

--- a/apis/model_test.go
+++ b/apis/model_test.go
@@ -1,14 +1,40 @@
 package apis
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/casbin/casbin/v2"
+	casbinModel "github.com/casbin/casbin/v2/model"
 	"github.com/gin-gonic/gin"
 	"github.com/mss-boot-io/mss-boot-admin/models"
 	adminPKG "github.com/mss-boot-io/mss-boot-admin/pkg"
+	"github.com/mss-boot-io/mss-boot/pkg/config/gormdb"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+type failingPolicyAdapter struct{}
+
+func (failingPolicyAdapter) LoadPolicy(casbinModel.Model) error {
+	return errors.New("load policy failed")
+}
+
+func (failingPolicyAdapter) SavePolicy(casbinModel.Model) error {
+	return nil
+}
+
+func (failingPolicyAdapter) AddPolicy(string, string, []string) error {
+	return nil
+}
+
+func (failingPolicyAdapter) RemovePolicy(string, string, []string) error {
+	return nil
+}
+
+func (failingPolicyAdapter) RemoveFilteredPolicy(string, string, int, ...string) error {
+	return nil
+}
 
 func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:model-menu-cleanup?mode=memory&cache=shared"), &gorm.Config{})
@@ -20,9 +46,10 @@ func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing
 	}
 
 	model := &models.Model{
-		Name:  "Orders",
-		Table: "orders",
-		Path:  "orders",
+		Name:          "Orders",
+		Table:         "orders",
+		Path:          "orders",
+		GeneratedData: true,
 	}
 	model.ID = "model-orders"
 	if err := db.Create(model).Error; err != nil {
@@ -47,6 +74,7 @@ func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing
 		{ID: 1, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/orders", V3: "GET"},
 		{ID: 2, PType: "p", V0: "role-1", V1: adminPKG.APIAccessType.String(), V2: "/admin/api/orders", V3: "GET"},
 		{ID: 3, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/keep", V3: "GET"},
+		{ID: 4, PType: "p", V0: "role-1", V1: adminPKG.ComponentAccessType.String(), V2: "/admin/api/orders", V3: "POST"},
 	}
 	if err := db.Create(&rules).Error; err != nil {
 		t.Fatalf("create rules: %v", err)
@@ -83,7 +111,7 @@ func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing
 
 	var generatedRules int64
 	if err := db.Model(&models.CasbinRule{}).
-		Where("v2 IN ?", []string{"/virtual/orders", "/admin/api/orders", "/virtual/orders/delete"}).
+		Where("id IN ?", []int{1, 2}).
 		Count(&generatedRules).Error; err != nil {
 		t.Fatalf("count generated rules: %v", err)
 	}
@@ -98,6 +126,14 @@ func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing
 	if keepRules != 1 {
 		t.Fatalf("expected unrelated policy to stay, got %d", keepRules)
 	}
+
+	var samePathRules int64
+	if err := db.Model(&models.CasbinRule{}).Where("id = ?", 4).Count(&samePathRules).Error; err != nil {
+		t.Fatalf("count same-path rule: %v", err)
+	}
+	if samePathRules != 1 {
+		t.Fatalf("expected same-path policy with different type/method to stay, got %d", samePathRules)
+	}
 }
 
 func TestDeleteGeneratedModelMenusKeepsMenuWhenAnotherActiveModelUsesPath(t *testing.T) {
@@ -109,9 +145,9 @@ func TestDeleteGeneratedModelMenusKeepsMenuWhenAnotherActiveModelUsesPath(t *tes
 		t.Fatalf("migrate db: %v", err)
 	}
 
-	deletedModel := &models.Model{Name: "Orders Old", Table: "orders_old", Path: "orders"}
+	deletedModel := &models.Model{Name: "Orders Old", Table: "orders_old", Path: "orders", GeneratedData: true}
 	deletedModel.ID = "model-orders-old"
-	activeModel := &models.Model{Name: "Orders Active", Table: "orders_active", Path: "orders"}
+	activeModel := &models.Model{Name: "Orders Active", Table: "orders_active", Path: "orders", GeneratedData: true}
 	activeModel.ID = "model-orders-active"
 	if err := db.Create(deletedModel).Error; err != nil {
 		t.Fatalf("create deleted model: %v", err)
@@ -154,5 +190,168 @@ func TestDeleteGeneratedModelMenusKeepsMenuWhenAnotherActiveModelUsesPath(t *tes
 	}
 	if activeRules != 1 {
 		t.Fatalf("expected shared-path policy to remain, got %d", activeRules)
+	}
+}
+
+func TestDeleteGeneratedModelMenusKeepsManualMenuWhenModelDataWasNotGenerated(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:model-menu-manual-path?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Model{}, &models.Menu{}, &models.CasbinRule{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	model := &models.Model{Name: "Manual Orders", Table: "orders", Path: "orders", GeneratedData: false}
+	model.ID = "model-manual-orders"
+	if err := db.Create(model).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	menu := &models.Menu{ParentID: "", Name: "Manual Orders", Path: "/virtual/orders", Type: adminPKG.MenuAccessType, Method: "GET"}
+	menu.ID = "menu-manual-root"
+	if err := db.Session(&gorm.Session{SkipHooks: true}).Create(menu).Error; err != nil {
+		t.Fatalf("create menu: %v", err)
+	}
+	rule := &models.CasbinRule{ID: 1, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/orders", V3: "GET"}
+	if err := db.Create(rule).Error; err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	if err := db.Delete(model).Error; err != nil {
+		t.Fatalf("delete model: %v", err)
+	}
+	ctx, _ := gin.CreateTestContext(nil)
+	ctx.Set("ids", []string{model.ID})
+
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err != nil {
+		t.Fatalf("delete generated menus: %v", err)
+	}
+
+	var activeMenus int64
+	if err := db.Model(&models.Menu{}).Where("id = ?", menu.ID).Count(&activeMenus).Error; err != nil {
+		t.Fatalf("count manual menu: %v", err)
+	}
+	if activeMenus != 1 {
+		t.Fatalf("expected manual menu to remain active, got %d", activeMenus)
+	}
+
+	var activeRules int64
+	if err := db.Model(&models.CasbinRule{}).Where("id = ?", rule.ID).Count(&activeRules).Error; err != nil {
+		t.Fatalf("count manual rule: %v", err)
+	}
+	if activeRules != 1 {
+		t.Fatalf("expected manual policy to remain, got %d", activeRules)
+	}
+}
+
+func TestDeleteGeneratedModelMenusRollsBackMenuSoftDeleteWhenPolicyDeleteFails(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:model-menu-policy-fail?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Model{}, &models.Menu{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	model := &models.Model{Name: "Orders", Table: "orders", Path: "orders", GeneratedData: true}
+	model.ID = "model-orders"
+	if err := db.Create(model).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	menu := &models.Menu{ParentID: "", Name: "Orders", Path: "/virtual/orders", Type: adminPKG.MenuAccessType, Method: "GET"}
+	menu.ID = "menu-root"
+	if err := db.Session(&gorm.Session{SkipHooks: true}).Create(menu).Error; err != nil {
+		t.Fatalf("create menu: %v", err)
+	}
+
+	if err := db.Delete(model).Error; err != nil {
+		t.Fatalf("delete model: %v", err)
+	}
+	ctx, _ := gin.CreateTestContext(nil)
+	ctx.Set("ids", []string{model.ID})
+
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err == nil {
+		t.Fatalf("expected policy delete error")
+	}
+
+	var activeMenus int64
+	if err := db.Model(&models.Menu{}).Where("id = ?", menu.ID).Count(&activeMenus).Error; err != nil {
+		t.Fatalf("count active menu: %v", err)
+	}
+	if activeMenus != 1 {
+		t.Fatalf("expected menu soft delete to roll back, got %d active menus", activeMenus)
+	}
+}
+
+func TestDeleteGeneratedModelMenusIgnoresLoadPolicyFailureAfterCleanup(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:model-menu-load-policy-fail?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Model{}, &models.Menu{}, &models.CasbinRule{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	model := &models.Model{Name: "Orders", Table: "orders", Path: "orders", GeneratedData: true}
+	model.ID = "model-orders"
+	if err := db.Create(model).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	menu := &models.Menu{ParentID: "", Name: "Orders", Path: "/virtual/orders", Type: adminPKG.MenuAccessType, Method: "GET"}
+	menu.ID = "menu-root"
+	if err := db.Session(&gorm.Session{SkipHooks: true}).Create(menu).Error; err != nil {
+		t.Fatalf("create menu: %v", err)
+	}
+	rule := &models.CasbinRule{ID: 1, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/orders", V3: "GET"}
+	if err := db.Create(rule).Error; err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	oldEnforcer := gormdb.Enforcer
+	defer func() {
+		gormdb.Enforcer = oldEnforcer
+	}()
+	enforcerModel, err := casbinModel.NewModelFromString(`[request_definition]
+r = sub, tp, obj, act
+[policy_definition]
+p = sub, tp, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && r.tp == p.tp && keyMatch(r.obj, p.obj) && regexMatch(r.act, p.act)`)
+	if err != nil {
+		t.Fatalf("create enforcer model: %v", err)
+	}
+	enforcer, err := casbin.NewEnforcer(enforcerModel)
+	if err != nil {
+		t.Fatalf("create enforcer: %v", err)
+	}
+	enforcer.SetAdapter(failingPolicyAdapter{})
+	gormdb.Enforcer = enforcer
+
+	if err := db.Delete(model).Error; err != nil {
+		t.Fatalf("delete model: %v", err)
+	}
+	ctx, _ := gin.CreateTestContext(nil)
+	ctx.Set("ids", []string{model.ID})
+
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err != nil {
+		t.Fatalf("delete generated menus: %v", err)
+	}
+
+	var deletedMenus int64
+	if err := db.Unscoped().Model(&models.Menu{}).Where("id = ? AND deleted_at IS NOT NULL", menu.ID).Count(&deletedMenus).Error; err != nil {
+		t.Fatalf("count deleted menu: %v", err)
+	}
+	if deletedMenus != 1 {
+		t.Fatalf("expected menu to be soft deleted, got %d", deletedMenus)
+	}
+
+	var rules int64
+	if err := db.Model(&models.CasbinRule{}).Where("id = ?", rule.ID).Count(&rules).Error; err != nil {
+		t.Fatalf("count rule: %v", err)
+	}
+	if rules != 0 {
+		t.Fatalf("expected policy to be deleted, got %d", rules)
 	}
 }

--- a/apis/model_test.go
+++ b/apis/model_test.go
@@ -1,0 +1,158 @@
+package apis
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mss-boot-io/mss-boot-admin/models"
+	adminPKG "github.com/mss-boot-io/mss-boot-admin/pkg"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestDeleteGeneratedModelMenusRemovesGeneratedMenuTreeAndPolicies(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:model-menu-cleanup?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Model{}, &models.Menu{}, &models.CasbinRule{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	model := &models.Model{
+		Name:  "Orders",
+		Table: "orders",
+		Path:  "orders",
+	}
+	model.ID = "model-orders"
+	if err := db.Create(model).Error; err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	menus := []*models.Menu{
+		{ParentID: "", Name: "Orders", Path: "/virtual/orders", Type: adminPKG.MenuAccessType, Method: "GET"},
+		{ParentID: "menu-root", Name: "Orders API", Path: "/admin/api/orders", Type: adminPKG.APIAccessType, Method: "GET"},
+		{ParentID: "menu-root", Name: "Orders Delete", Path: "/virtual/orders/delete", Type: adminPKG.ComponentAccessType, Method: "GET"},
+		{ParentID: "", Name: "Keep", Path: "/virtual/keep", Type: adminPKG.MenuAccessType, Method: "GET"},
+	}
+	menus[0].ID = "menu-root"
+	menus[1].ID = "menu-api"
+	menus[2].ID = "menu-delete"
+	menus[3].ID = "menu-keep"
+	if err := db.Session(&gorm.Session{SkipHooks: true}).Create(&menus).Error; err != nil {
+		t.Fatalf("create menus: %v", err)
+	}
+
+	rules := []*models.CasbinRule{
+		{ID: 1, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/orders", V3: "GET"},
+		{ID: 2, PType: "p", V0: "role-1", V1: adminPKG.APIAccessType.String(), V2: "/admin/api/orders", V3: "GET"},
+		{ID: 3, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/keep", V3: "GET"},
+	}
+	if err := db.Create(&rules).Error; err != nil {
+		t.Fatalf("create rules: %v", err)
+	}
+
+	if err := db.Delete(model).Error; err != nil {
+		t.Fatalf("delete model: %v", err)
+	}
+	ctx, _ := gin.CreateTestContext(nil)
+	ctx.Set("ids", []string{model.ID})
+
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err != nil {
+		t.Fatalf("delete generated menus: %v", err)
+	}
+
+	var deletedGeneratedMenus int64
+	if err := db.Unscoped().Model(&models.Menu{}).
+		Where("id IN ?", []string{"menu-root", "menu-api", "menu-delete"}).
+		Where("deleted_at IS NOT NULL").
+		Count(&deletedGeneratedMenus).Error; err != nil {
+		t.Fatalf("count deleted menus: %v", err)
+	}
+	if deletedGeneratedMenus != 3 {
+		t.Fatalf("expected 3 generated menus deleted, got %d", deletedGeneratedMenus)
+	}
+
+	var activeKeepMenus int64
+	if err := db.Model(&models.Menu{}).Where("id = ?", "menu-keep").Count(&activeKeepMenus).Error; err != nil {
+		t.Fatalf("count keep menu: %v", err)
+	}
+	if activeKeepMenus != 1 {
+		t.Fatalf("expected unrelated menu to stay active, got %d", activeKeepMenus)
+	}
+
+	var generatedRules int64
+	if err := db.Model(&models.CasbinRule{}).
+		Where("v2 IN ?", []string{"/virtual/orders", "/admin/api/orders", "/virtual/orders/delete"}).
+		Count(&generatedRules).Error; err != nil {
+		t.Fatalf("count generated rules: %v", err)
+	}
+	if generatedRules != 0 {
+		t.Fatalf("expected generated policies removed, got %d", generatedRules)
+	}
+
+	var keepRules int64
+	if err := db.Model(&models.CasbinRule{}).Where("v2 = ?", "/virtual/keep").Count(&keepRules).Error; err != nil {
+		t.Fatalf("count keep rules: %v", err)
+	}
+	if keepRules != 1 {
+		t.Fatalf("expected unrelated policy to stay, got %d", keepRules)
+	}
+}
+
+func TestDeleteGeneratedModelMenusKeepsMenuWhenAnotherActiveModelUsesPath(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:model-menu-active-path?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Model{}, &models.Menu{}, &models.CasbinRule{}); err != nil {
+		t.Fatalf("migrate db: %v", err)
+	}
+
+	deletedModel := &models.Model{Name: "Orders Old", Table: "orders_old", Path: "orders"}
+	deletedModel.ID = "model-orders-old"
+	activeModel := &models.Model{Name: "Orders Active", Table: "orders_active", Path: "orders"}
+	activeModel.ID = "model-orders-active"
+	if err := db.Create(deletedModel).Error; err != nil {
+		t.Fatalf("create deleted model: %v", err)
+	}
+	if err := db.Create(activeModel).Error; err != nil {
+		t.Fatalf("create active model: %v", err)
+	}
+
+	menu := &models.Menu{ParentID: "", Name: "Orders", Path: "/virtual/orders", Type: adminPKG.MenuAccessType, Method: "GET"}
+	menu.ID = "menu-root"
+	if err := db.Session(&gorm.Session{SkipHooks: true}).Create(menu).Error; err != nil {
+		t.Fatalf("create menu: %v", err)
+	}
+	rule := &models.CasbinRule{ID: 1, PType: "p", V0: "role-1", V1: adminPKG.MenuAccessType.String(), V2: "/virtual/orders", V3: "GET"}
+	if err := db.Create(rule).Error; err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	if err := db.Delete(deletedModel).Error; err != nil {
+		t.Fatalf("delete model: %v", err)
+	}
+	ctx, _ := gin.CreateTestContext(nil)
+	ctx.Set("ids", []string{deletedModel.ID})
+
+	if err := deleteGeneratedModelMenus(ctx, db, &models.Model{}); err != nil {
+		t.Fatalf("delete generated menus: %v", err)
+	}
+
+	var activeMenus int64
+	if err := db.Model(&models.Menu{}).Where("id = ?", menu.ID).Count(&activeMenus).Error; err != nil {
+		t.Fatalf("count menu: %v", err)
+	}
+	if activeMenus != 1 {
+		t.Fatalf("expected shared-path menu to remain active, got %d", activeMenus)
+	}
+
+	var activeRules int64
+	if err := db.Model(&models.CasbinRule{}).Where("v2 = ?", "/virtual/orders").Count(&activeRules).Error; err != nil {
+		t.Fatalf("count rule: %v", err)
+	}
+	if activeRules != 1 {
+		t.Fatalf("expected shared-path policy to remain, got %d", activeRules)
+	}
+}


### PR DESCRIPTION
## Summary

- Partially addresses #75 by fixing the confirmed sub-problem where deleting a generated model leaves its MenuBar entry behind.
- Adds a model delete hook that recursively soft-deletes the generated `/virtual/<model.path>` menu tree.
- Removes Casbin policies tied to the generated menu/API paths and reloads policies after cleanup.
- Keeps the generated menu when another active model still uses the same `path`, avoiding accidental cleanup of shared-path models.
- Adds focused SQLite coverage to ensure unrelated menus and policies are not touched.

## Scope note

Issue #75 contains several independent bugs plus one feature suggestion. This PR intentionally fixes only the model-delete/menu-cleanup sub-problem because it is directly confirmed by current code. The remaining items still need separate reproduction details before they can be closed cleanly.

## Tests

- [x] I ran `make test` or documented why it is not applicable.
- [x] I included test output or a clear verification note.

Verification:

```text
go test ./apis
go test ./apis ./models ./middleware
```

## Docs

- [x] I updated README, docs, swagger, changelog, or AI memory when behavior changed.
- [ ] No documentation update is needed.

AI memory recorded at `aigc/prompts/model-delete-menu-cleanup-2026-06-07.zh-CN.md`.

## Security

- [x] I considered authentication, authorization, RBAC, data exposure, secrets, and dependency impact.
- [ ] No security-sensitive behavior changed.

This change removes stale menu/API policies only for menus generated from deleted models. It does not grant new permissions.

## Release

- [x] I considered database/config migrations, image tag, deployment order, rollback, and compatibility.
- [ ] No release note is needed.

No migration is required. The cleanup runs when a model is deleted.