### PR TITLE
fix: keep PostgreSQL migrations compatible after tenant cleanup

### DIFF
--- a/aigc/prompts/legacy-tenant-column-migration-2026-06-07.zh-CN.md
+++ b/aigc/prompts/legacy-tenant-column-migration-2026-06-07.zh-CN.md
@@ -1,0 +1,20 @@
+# 2026-06-07 dev 验证阻塞：遗留 tenant_id 非空列兼容迁移
+
+## 背景
+
+- 当前 dev 环境 `mss-boot-dev` 使用 PostgreSQL/TimescaleDB 旧库。
+- 代码中的 `models.ModelGormTenant` 已经收敛为兼容空壳，不再映射 `tenant_id` 字段。
+- dev 库中仍有多张旧表保留 `tenant_id NOT NULL`，导致新镜像 init migration 在 `1772445829126` 写入 `mss_boot_menus` 时失败。
+
+## 决策
+
+- 不恢复租户字段，不在业务插入点硬编码默认租户。
+- 在 `1772445829126` 开始处释放遗留 `tenant_id NOT NULL`，保证卡在该版本前的旧库可继续迁移。
+- 新增 `20260607072000_relax_legacy_tenant_columns`，保证已经跑过旧迁移的环境也能补齐同样 schema 兼容。
+- PostgreSQL 使用 `ALTER COLUMN tenant_id DROP NOT NULL`；MySQL 保留 `information_schema.columns.column_type` 后 `MODIFY COLUMN ... NULL`；SQLite 暂不处理。
+
+## 验证目标
+
+- `go test ./cmd/migrate/migration/system`。
+- dev 环境新镜像 init migration 不再因 `tenant_id` 非空失败。
+- 后续 #371/#372 的 dev 验证必须基于包含该迁移兼容修复的验证镜像。

--- a/aigc/prompts/legacy-tenant-column-migration-2026-06-07.zh-CN.md
+++ b/aigc/prompts/legacy-tenant-column-migration-2026-06-07.zh-CN.md
@@ -18,3 +18,8 @@
 - `go test ./cmd/migrate/migration/system`。
 - dev 环境新镜像 init migration 不再因 `tenant_id` 非空失败。
 - 后续 #371/#372 的 dev 验证必须基于包含该迁移兼容修复的验证镜像。
+
+## 追加发现
+
+- 解除 `tenant_id NOT NULL` 后，dev migration 继续暴露 PostgreSQL 方言问题：`Menu.AfterCreate` 和 `1691847581348` 迁移使用 MySQL 反引号查询 `default` 列。
+- 修复方式：统一使用 `gorm.io/gorm/clause` 构造 `default = true` 条件，让 GORM 按当前数据库方言 quote 标识符。

--- a/aigc/prompts/readme.zh-CN.md
+++ b/aigc/prompts/readme.zh-CN.md
@@ -26,3 +26,4 @@
 - `multi-tenant-cache-evaluation.zh-CN.md`
 - `tenant-removal-impact-plan.zh-CN.md`
 - `tenant-removal-handoff-summary.zh-CN.md`
+- `legacy-tenant-column-migration-2026-06-07.zh-CN.md`

--- a/cmd/migrate/migration/system/1691847581348_migrate.go
+++ b/cmd/migrate/migration/system/1691847581348_migrate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mss-boot-io/mss-boot/pkg/migration"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var (
@@ -156,7 +157,9 @@ oauth2:
 		}
 
 		adminRole := &models.Role{Default: true}
-		err = tx.Model(&models.Role{}).Where("`default` = ?", true).First(adminRole).Error
+		err = tx.Model(&models.Role{}).
+			Where(clause.Eq{Column: clause.Column{Name: "default"}, Value: true}).
+			First(adminRole).Error
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				return err

--- a/cmd/migrate/migration/system/1772445829126_migrate.go
+++ b/cmd/migrate/migration/system/1772445829126_migrate.go
@@ -17,6 +17,9 @@ func init() {
 
 func _1772445829126Migrate(db *gorm.DB, version string) error {
 	return db.Transaction(func(tx *gorm.DB) error {
+		if err := relaxLegacyTenantColumns(tx); err != nil {
+			return err
+		}
 
 		// TODO: here to write the content to be changed
 

--- a/cmd/migrate/migration/system/20260607072000_relax_legacy_tenant_columns.go
+++ b/cmd/migrate/migration/system/20260607072000_relax_legacy_tenant_columns.go
@@ -1,0 +1,22 @@
+package system
+
+import (
+	"runtime"
+
+	"github.com/mss-boot-io/mss-boot/pkg/migration"
+	"gorm.io/gorm"
+)
+
+func init() {
+	_, fileName, _, _ := runtime.Caller(0)
+	migration.Migrate.SetVersion(migration.GetFilename(fileName), _20260607072000RelaxLegacyTenantColumns)
+}
+
+func _20260607072000RelaxLegacyTenantColumns(db *gorm.DB, version string) error {
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := relaxLegacyTenantColumns(tx); err != nil {
+			return err
+		}
+		return migration.Migrate.CreateVersion(tx, version)
+	})
+}

--- a/cmd/migrate/migration/system/legacy_tenant_columns.go
+++ b/cmd/migrate/migration/system/legacy_tenant_columns.go
@@ -1,0 +1,89 @@
+package system
+
+import (
+	"log/slog"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type legacyTenantColumn struct {
+	TableName  string `gorm:"column:table_name"`
+	ColumnType string `gorm:"column:column_type"`
+}
+
+func relaxLegacyTenantColumns(tx *gorm.DB) error {
+	query, ok := legacyTenantColumnsQuery(tx.Dialector.Name())
+	if !ok {
+		return nil
+	}
+
+	var columns []legacyTenantColumn
+	if err := tx.Raw(query).Scan(&columns).Error; err != nil {
+		return err
+	}
+
+	for i := range columns {
+		sql, ok := relaxLegacyTenantColumnSQL(tx.Dialector.Name(), columns[i])
+		if !ok {
+			continue
+		}
+		if err := tx.Exec(sql).Error; err != nil {
+			return err
+		}
+		slog.Info("relaxed legacy tenant_id NOT NULL constraint",
+			"dialect", tx.Dialector.Name(),
+			"table", columns[i].TableName)
+	}
+	return nil
+}
+
+func legacyTenantColumnsQuery(dialect string) (string, bool) {
+	switch dialect {
+	case "postgres":
+		return `SELECT table_name, '' AS column_type
+FROM information_schema.columns
+WHERE table_schema = CURRENT_SCHEMA()
+  AND column_name = 'tenant_id'
+  AND is_nullable = 'NO'
+ORDER BY table_name`, true
+	case "mysql":
+		return `SELECT table_name, column_type
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND column_name = 'tenant_id'
+  AND is_nullable = 'NO'
+ORDER BY table_name`, true
+	default:
+		return "", false
+	}
+}
+
+func relaxLegacyTenantColumnSQL(dialect string, column legacyTenantColumn) (string, bool) {
+	if column.TableName == "" {
+		return "", false
+	}
+	switch dialect {
+	case "postgres":
+		return "ALTER TABLE " + quoteIdentifier(dialect, column.TableName) +
+			" ALTER COLUMN " + quoteIdentifier(dialect, "tenant_id") + " DROP NOT NULL", true
+	case "mysql":
+		columnType := column.ColumnType
+		if columnType == "" {
+			columnType = "varchar(64)"
+		}
+		return "ALTER TABLE " + quoteIdentifier(dialect, column.TableName) +
+			" MODIFY COLUMN " + quoteIdentifier(dialect, "tenant_id") + " " + columnType + " NULL", true
+	default:
+		return "", false
+	}
+}
+
+func quoteIdentifier(dialect, identifier string) string {
+	switch dialect {
+	case "mysql":
+		return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+	default:
+		return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+	}
+}

--- a/cmd/migrate/migration/system/legacy_tenant_columns_test.go
+++ b/cmd/migrate/migration/system/legacy_tenant_columns_test.go
@@ -1,0 +1,38 @@
+package system
+
+import "testing"
+
+func TestLegacyTenantColumnsQuery(t *testing.T) {
+	if _, ok := legacyTenantColumnsQuery("postgres"); !ok {
+		t.Fatal("postgres should be supported")
+	}
+	if _, ok := legacyTenantColumnsQuery("mysql"); !ok {
+		t.Fatal("mysql should be supported")
+	}
+	if _, ok := legacyTenantColumnsQuery("sqlite"); ok {
+		t.Fatal("sqlite should be ignored")
+	}
+}
+
+func TestRelaxLegacyTenantColumnSQL(t *testing.T) {
+	sql, ok := relaxLegacyTenantColumnSQL("postgres", legacyTenantColumn{TableName: `mss_boot"menus`})
+	if !ok {
+		t.Fatal("postgres should build SQL")
+	}
+	want := `ALTER TABLE "mss_boot""menus" ALTER COLUMN "tenant_id" DROP NOT NULL`
+	if sql != want {
+		t.Fatalf("postgres SQL mismatch\nwant: %s\n got: %s", want, sql)
+	}
+
+	sql, ok = relaxLegacyTenantColumnSQL("mysql", legacyTenantColumn{
+		TableName:  "mss_boot_menus",
+		ColumnType: "varchar(36)",
+	})
+	if !ok {
+		t.Fatal("mysql should build SQL")
+	}
+	want = "ALTER TABLE `mss_boot_menus` MODIFY COLUMN `tenant_id` varchar(36) NULL"
+	if sql != want {
+		t.Fatalf("mysql SQL mismatch\nwant: %s\n got: %s", want, sql)
+	}
+}

--- a/models/menu.go
+++ b/models/menu.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mss-boot-io/mss-boot/pkg/enum"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"github.com/mss-boot-io/mss-boot-admin/pkg"
 )
@@ -111,7 +112,9 @@ func (e *Menu) AfterCreate(tx *gorm.DB) error {
 		return nil
 	}
 	var defaultRole Role
-	if err := tx.Model(&Role{}).Where("`default` = ?", true).First(&defaultRole).Error; err != nil {
+	if err := tx.Model(&Role{}).
+		Where(clause.Eq{Column: clause.Column{Name: "default"}, Value: true}).
+		First(&defaultRole).Error; err != nil {
 		return nil
 	}
 	method := e.Method

--- a/models/menu_test.go
+++ b/models/menu_test.go
@@ -1,0 +1,43 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/mss-boot-io/mss-boot-admin/pkg"
+	"github.com/mss-boot-io/mss-boot/pkg/enum"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestMenuAfterCreateUsesQuotedDefaultRoleColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&Role{}, &Menu{}, &CasbinRule{}))
+
+	role := &Role{Name: "admin", Status: enum.Enabled}
+	require.NoError(t, db.Create(role).Error)
+	require.NoError(t, db.Exec(`UPDATE mss_boot_roles SET "default" = ? WHERE id = ?`, true, role.ID).Error)
+
+	menu := &Menu{
+		Name:       "menu.test",
+		Path:       "/test",
+		Method:     "GET",
+		Component:  "./Test",
+		Icon:       "experiment",
+		Type:       pkg.MenuAccessType,
+		Permission: "/test",
+		Status:     enum.Enabled,
+	}
+	require.NoError(t, db.Create(menu).Error)
+
+	var count int64
+	require.NoError(t, db.Model(&CasbinRule{}).Where(&CasbinRule{
+		PType: "p",
+		V0:    role.ID,
+		V1:    pkg.MenuAccessType.String(),
+		V2:    "/test",
+		V3:    "GET",
+	}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}


### PR DESCRIPTION
## Summary
- relax legacy `tenant_id NOT NULL` columns before the old menu migration writes tenant-less rows
- add a follow-up migration so already-upgraded databases receive the same compatibility fix
- replace MySQL-style backtick quoting for the `default` role lookup with GORM clause-based identifier quoting
- add focused tests for migration SQL generation and menu policy creation

## Context
This was found while validating PR #371 and PR #372 on the `mss-boot-dev` PostgreSQL/TimescaleDB environment. The validation image reached the old `1772445829126` migration and exposed two PostgreSQL blockers unrelated to the original issue fixes:

- legacy databases still had `tenant_id NOT NULL` columns while current `ModelGormTenant` no longer maps `tenant_id`
- `Menu.AfterCreate` and an older migration queried the `default` column with MySQL backticks

## Tests
- `go test ./models ./cmd/migrate/migration/system`
- `go test ./config ./apis ./models ./middleware ./cmd/migrate/migration/system`
- `make test`
- deployed combined validation image `ghcr.io/mss-boot-io/mss-boot-admin:015cf4d5dd895d65328cb6dfea4416b14f19612a` to `mss-boot-dev`
- verified init migration completed, service became ready, authenticated API smoke passed, temporary Option CRUD passed, and generated Model menu cleanup removed active menus and policies

## Docs
- Added AIGC memory at `aigc/prompts/legacy-tenant-column-migration-2026-06-07.zh-CN.md`
- Updated `aigc/prompts/readme.zh-CN.md`

## Security
- No credential, auth, or permission broadening changes
- Casbin behavior is unchanged except that generated menu cleanup validation can now run on PostgreSQL successfully
