### PR TITLE
docs: document admin test prerequisites and rbac glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,22 @@ The project has undergone comprehensive polish rounds focusing on:
 - Account and token management: Support OAuth2 binding and personal access tokens.
 - Monitoring and statistics: Provide runtime visibility and statistics querying capabilities.
 
+## RBAC Glossary
+
+| Term | Meaning in mss-boot-admin |
+| --- | --- |
+| User | A system operator. Users authenticate, receive roles, and operate within the permissions granted by those roles. |
+| Role | A permission group stored in `mss_boot_roles`. Roles are the main subject in Casbin policies and are assigned to users. |
+| Menu | A frontend navigation or permission node stored in `mss_boot_menus`. Menu records can represent directories, pages, components, or API permission nodes. |
+| API | A backend route record stored in `mss_boot_api`, usually generated from Gin route metadata and used for permission governance. |
+| Permission path | The menu/API path written into authorization requests and Casbin rules. Duplicate or blank paths are ignored before rules are built. |
+| Casbin rule | A policy row in `mss_boot_casbin_rule`. The common shape is `p, roleID, accessType, path, method`. |
+| Access type | The rule scope, such as `MENU`, `API`, or component access. Role authorization can combine menu rules and child API rules. |
+| Data scope | The organization/data boundary attached to a role. It controls which department-owned data a role should be able to access. |
+| Default role | A role marked as default. New menu access can be granted to it automatically when menu records are created. |
+
 ## 📦 Preparation
-- Install golang1.21+
+- Install Go 1.26+
 - Install mysql8.0+
 - Install nodejs18.16.0+
 
@@ -163,6 +177,18 @@ If you think this project helped you, you can buy a glass of juice for the autho
 ## Testing
 
 The project follows strict testing requirements to ensure code quality and reliability.
+
+### Local Test Prerequisites
+
+`make test` runs `go test -coverprofile=coverage.out ./...`. Before opening a backend PR, check these local prerequisites:
+
+- Use Go 1.26+, matching `go.mod` and GitHub Actions.
+- Run `make deps` once after pulling dependency or `go.sum` changes.
+- Redis-backed tests generally use `miniredis`, but a local Redis 7 instance is useful when validating cache/session behavior manually.
+- No real production DSN, token, Kubernetes cluster, or private credential is required for `make test`.
+- CI starts Redis 7 with `supercharge/redis-github-action`, then runs `make deps`, `make test`, and `make build`.
+
+If a local test fails because an optional external service is unavailable, mention that in the PR verification notes and include the exact command output. Do not paste real credentials or production endpoints.
 
 ### Test Types
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -59,8 +59,22 @@
 - 账号与令牌管理: 支持 OAuth2 绑定、个人令牌等账号安全能力。
 - 监控与统计: 支持基础监控信息与统计查询接口。
 
+## RBAC 术语表
+
+| 术语 | 在 mss-boot-admin 中的含义 |
+| --- | --- |
+| 用户 | 系统操作者。用户完成认证后，通过被分配的角色获得操作权限。 |
+| 角色 | 存储在 `mss_boot_roles` 中的权限分组，是 Casbin 策略中的主要主体，并可分配给用户。 |
+| 菜单 | 存储在 `mss_boot_menus` 中的前端导航或权限节点，可表示目录、页面、组件或 API 权限节点。 |
+| API | 存储在 `mss_boot_api` 中的后端路由记录，通常由 Gin route 元数据生成，用于接口治理和权限映射。 |
+| 权限路径 | 授权请求和 Casbin rule 中写入的菜单/API path；空路径和重复路径会在构建规则前被过滤。 |
+| Casbin rule | 存储在 `mss_boot_casbin_rule` 中的策略行，常见形态为 `p, roleID, accessType, path, method`。 |
+| Access type | 权限规则范围，例如 `MENU`、`API` 或组件访问；角色授权可以同时包含菜单规则和子 API 规则。 |
+| 数据范围 | 附着在角色上的组织/数据边界，用于限制角色可访问的部门归属数据。 |
+| 默认角色 | 被标记为 default 的角色。创建菜单记录时，可自动授予默认角色对应的菜单访问规则。 |
+
 ## 📦 准备工作
-- 安装golang1.21+
+- 安装 Go 1.26+
 - 安装mysql8.0+
 - 安装nodejs18.16.0+
 
@@ -101,6 +115,18 @@ npm install
 # 启动前端服务
 npm run start
 ```
+
+## 本地测试前置条件
+
+`make test` 会执行 `go test -coverprofile=coverage.out ./...`。提交后端 PR 前建议确认：
+
+- 使用 Go 1.26+，与 `go.mod` 和 GitHub Actions 保持一致。
+- 拉取依赖或 `go.sum` 变更后先执行一次 `make deps`。
+- Redis 相关测试通常使用 `miniredis`，但手动验证缓存/session 行为时建议准备本地 Redis 7。
+- `make test` 不需要真实生产 DSN、token、Kubernetes 集群或私有凭据。
+- CI 会通过 `supercharge/redis-github-action` 启动 Redis 7，然后执行 `make deps`、`make test` 和 `make build`。
+
+如果本地测试因为可选外部服务不可用而失败，请在 PR 验证说明中写明具体命令和错误摘要，不要粘贴真实凭据或生产端点。
 
 ## 📨 互动
 <table>

--- a/aigc/prompts/readme-test-rbac-glossary-2026-06-09.zh-CN.md
+++ b/aigc/prompts/readme-test-rbac-glossary-2026-06-09.zh-CN.md
@@ -1,0 +1,23 @@
+# README 测试前置条件与 RBAC 术语表记忆
+
+- 日期：2026-06-09
+- 仓库：mss-boot-admin
+- 对应 issue：#344、#345
+
+## 本轮处理
+
+- README / README.zh-CN 的准备工作中，将后端 Go 版本说明对齐到 `go.mod` 和 CI：Go 1.26+。
+- 英文 README 新增 `Local Test Prerequisites`，说明 `make test`、`make deps`、Redis 7、CI 服务准备方式和敏感信息边界。
+- 中文 README 新增 `本地测试前置条件`，覆盖同一验证口径。
+- README / README.zh-CN 新增 RBAC 术语表，解释 User、Role、Menu、API、Permission path、Casbin rule、Access type、Data scope、Default role。
+
+## 边界
+
+- 本轮只改文档与 AIGC 记忆，不修改权限模型、菜单、路由、迁移、seed data 或生产配置。
+- 测试说明不包含真实生产 DSN、token、Kubernetes 集群或私有端点。
+
+## 验证
+
+- `make test`
+- `git diff --check`
+- 静态 README 检查：确认 Go 1.26、Redis 7、`make test`、RBAC 关键术语均存在。

--- a/aigc/prompts/readme.zh-CN.md
+++ b/aigc/prompts/readme.zh-CN.md
@@ -27,3 +27,4 @@
 - `tenant-removal-impact-plan.zh-CN.md`
 - `tenant-removal-handoff-summary.zh-CN.md`
 - `legacy-tenant-column-migration-2026-06-07.zh-CN.md`
+- `readme-test-rbac-glossary-2026-06-09.zh-CN.md`


### PR DESCRIPTION
## Summary
- document the local `make test` prerequisites for the admin backend
- add an RBAC glossary so contributors can map users, roles, menus, APIs, Casbin rules, access types, and data scopes consistently
- record the AIGC memory for this community issue follow-up

Closes #344
Closes #345

## Documentation Impact
- updates the English and Chinese README files only
- aligns the documented Go baseline with the current repository requirement, Go 1.26+
- explains the Redis-backed test setup already used by CI

## Security Notes
- no permission model, route, policy, seed data, migration, or production configuration changed
- the glossary describes the current RBAC concepts without expanding access behavior

## Tests Impact
- no runtime behavior changes
- validated that the documented `make test` path still runs locally

## Verification
- `make test`
- `git diff --check`
- static README check for Go 1.26, Redis 7, RBAC glossary terms, and issue references

## Release Safety
- documentation-only change; no beta deployment required
