### PR TITLE
test: cover language fallback middleware

### DIFF
--- a/aigc/prompts/language-fallback-test-2026-06-09.zh-CN.md
+++ b/aigc/prompts/language-fallback-test-2026-06-09.zh-CN.md
@@ -1,0 +1,25 @@
+# language middleware fallback 测试记忆
+
+## 背景
+
+- 时间：2026-06-09
+- 仓库：`mss-boot-admin`
+- 关联 issue：`mss-boot-io/mss-boot-admin#346`
+- 目标：补齐语言中间件 fallback 行为的独立单测，让贡献者可以在不依赖数据库、Redis、外部服务的情况下验证用户可见的语言选择逻辑。
+
+## 实施
+
+- 新增 `middleware/language_test.go`。
+- 覆盖空 `Accept-Language`、受支持语言、带权重后缀的语言、区域语言归一化、不支持语言 fallback、query 参数 fallback、`Content-Language` fallback。
+- 同时断言 `GetLanguage(c)` 和响应 `Content-Language` 头，确保 middleware 写入 context 与响应头的一致性。
+
+## 验证
+
+- `go test ./middleware`
+- `go test ./...`
+
+## 约束
+
+- 不修改产品行为。
+- 不改权限、路由、数据库迁移、种子数据、缓存或生产配置。
+- 此类社区 issue 适合保持小 PR、强验证、清晰说明，便于外部贡献者 review。

--- a/aigc/prompts/readme.zh-CN.md
+++ b/aigc/prompts/readme.zh-CN.md
@@ -27,3 +27,4 @@
 - `tenant-removal-impact-plan.zh-CN.md`
 - `tenant-removal-handoff-summary.zh-CN.md`
 - `legacy-tenant-column-migration-2026-06-07.zh-CN.md`
+- `language-fallback-test-2026-06-09.zh-CN.md`

--- a/middleware/language_test.go
+++ b/middleware/language_test.go
@@ -1,0 +1,101 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestLanguageMiddlewareFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name            string
+		acceptLanguage  string
+		contentLanguage string
+		query           string
+		want            string
+	}{
+		{
+			name: "empty header uses default language",
+			want: DefaultLang,
+		},
+		{
+			name:           "supported accept language is preserved",
+			acceptLanguage: "en-US",
+			want:           "en-US",
+		},
+		{
+			name:           "accept language quality suffix is ignored",
+			acceptLanguage: "zh-CN;q=0.9,en-US;q=0.8",
+			want:           "zh-CN",
+		},
+		{
+			name:           "regional language falls back to supported family",
+			acceptLanguage: "en-GB",
+			want:           "en-US",
+		},
+		{
+			name:           "unsupported language falls back to default",
+			acceptLanguage: "fr-FR",
+			want:           DefaultLang,
+		},
+		{
+			name:  "query language is used when accept language is empty",
+			query: "?lang=en",
+			want:  "en",
+		},
+		{
+			name:            "content language is used after empty accept language and query",
+			contentLanguage: "zh-TW",
+			want:            "zh-CN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.Use(Language())
+			router.GET("/language", func(c *gin.Context) {
+				lang := GetLanguage(c)
+				if lang != tt.want {
+					t.Fatalf("GetLanguage() = %q, want %q", lang, tt.want)
+				}
+				c.Status(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/language"+tt.query, nil)
+			if tt.acceptLanguage != "" {
+				req.Header.Set("Accept-Language", tt.acceptLanguage)
+			}
+			if tt.contentLanguage != "" {
+				req.Header.Set("Content-Language", tt.contentLanguage)
+			}
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+			}
+			if got := rec.Header().Get("Content-Language"); got != tt.want {
+				t.Fatalf("Content-Language = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLanguageHelpers(t *testing.T) {
+	if got := parseAcceptLanguage(" en-US;q=0.8, zh-CN;q=0.7 "); got != "en-US" {
+		t.Fatalf("parseAcceptLanguage() = %q, want en-US", got)
+	}
+
+	if !IsSupportedLanguage("zh-CN") {
+		t.Fatalf("zh-CN should be supported")
+	}
+	if IsSupportedLanguage("fr-FR") {
+		t.Fatalf("fr-FR should not be supported")
+	}
+}


### PR DESCRIPTION
## Summary
- add isolated coverage for the language middleware fallback behavior
- cover empty headers, supported languages, weighted headers, regional normalization, unsupported-language fallback, query fallback, and `Content-Language` fallback
- record AIGC memory for the community issue follow-up

Closes #346

## Documentation Impact
- adds an AIGC memory note for the issue and validation scope
- no public docs or API docs regenerated

## Security Notes
- no authentication, authorization, route, migration, seed data, cache, or production configuration changes
- the test documents current behavior only

## Tests Impact
- adds deterministic middleware unit tests that do not require database, Redis, or external services
- keeps the behavior unchanged unless CI exposes a regression

## Verification
- `go test ./middleware`
- `go test ./...`
- `git diff --check`

## Release Safety
- test-only backend change; no beta deployment required
