### PR TITLE
refactor(mss-boot): harden framework runtime and request contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'codex/**'
     tags:
       - 'v*.*.*'
+      - 'mss-boot/v*.*.*'
     paths-ignore:
       - 'docs/**'
       - 'web/antd/**'
@@ -38,6 +39,10 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          cache-dependency-path: |
+            go.sum
+            mss-boot/go.sum
+            cmd/tools/pr/go.sum
 
       - name: Start Redis
         uses: supercharge/redis-github-action@1.8.1
@@ -49,6 +54,15 @@ jobs:
 
       - name: Unit tests
         run: make test-all
+
+      - name: Framework race tests
+        run: make test-framework-race
+
+      - name: Framework vet
+        run: make vet-framework
+
+      - name: Verify framework module metadata
+        run: make tidy-framework-check
 
       - name: Convert coverage report to table
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PROJECT:=mss-boot-admin
 
 .PHONY: build test deps generate lint fix-lint \
-	deps-framework deps-all test-framework test-all \
+	deps-framework deps-all test-framework test-framework-race \
+	vet-framework tidy-framework-check verify-framework test-all \
 	web-install web-lint web-test web-build docs-install docs-build verify-all
 
 build:
@@ -19,7 +20,19 @@ deps-framework:
 deps-all: deps deps-framework
 
 test-framework:
-	cd mss-boot && go test ./...
+	cd mss-boot && GOWORK=off go test -shuffle=on -count=1 ./...
+
+test-framework-race:
+	cd mss-boot && GOWORK=off go test -race -shuffle=on -count=1 ./...
+
+vet-framework:
+	cd mss-boot && GOWORK=off go vet ./...
+
+tidy-framework-check:
+	cd mss-boot && GOWORK=off go mod tidy
+	git diff --exit-code -- mss-boot/go.mod mss-boot/go.sum
+
+verify-framework: test-framework-race vet-framework tidy-framework-check
 
 test-all: test-framework test
 
@@ -50,4 +63,4 @@ docs-install:
 docs-build:
 	cd docs && pnpm build
 
-verify-all: test-all web-lint web-test web-build docs-build
+verify-all: verify-framework test web-lint web-test web-build docs-build

--- a/mss-boot/CHANGELOG.md
+++ b/mss-boot/CHANGELOG.md
@@ -1,216 +1,98 @@
 # Changelog
 
-All notable changes to the mss-boot framework will be documented in this file.
+All notable, verifiable changes to the `mss-boot` framework are documented in
+this file. The format follows [Keep a Changelog](https://keepachangelog.com/),
+and the project uses semantic versioning for nested-module releases.
 
-## [v0.7.3] - 2026-06-07
-
-### Added
-
-- Structured GitHub issue forms and refreshed open-source entry points.
-- Local developer Makefile targets for `test`, `coverage`, and `tidy`.
-
-### Changed
-
-- Refreshed README quick-start guidance to use the latest `v0.7.3` module version.
-- Corrected Makefile build metadata import path to `github.com/mss-boot-io/mss-boot`.
-
-### Fixed
-
-- Kept GORM query-cache tag invalidation complete for create, update, and delete paths.
-- Hardened Mongo delete handling by validating ObjectID input before deletion.
-
-### Validation
-
-- GitHub CI, lint, CodeQL, docs-drift, PR guard, and govulncheck passed before release.
-- Local `go test ./pkg/response/actions/mgm ./...` passed on the release commit.
-
-## [v0.7.1] - 2026-04-06
+## Unreleased
 
 ### Added
 
-#### Core Framework Enhancements
-- **Advanced Error Handling**: Standardized error codes with comprehensive error categorization
-- **Action Scope Management**: Context-aware operation scoping for better resource management
-- **Enhanced Testing Infrastructure**: Comprehensive test suite with 80%+ coverage requirements
-- **Integration Testing Support**: Robust integration tests for database and API interactions
-
-#### Documentation
-- **Comprehensive API Documentation**: Complete Swagger documentation for all core components
-- **Migration Guides**: Clear upgrade paths from previous versions
-- **Usage Examples**: Detailed code examples for common use cases
+- Blocking lifecycle regression tests for cancellation, peer-error propagation,
+  unexpected exits, graceful-shutdown deadlines, duplicate starts, and signal
+  ownership.
+- HTTP and gRPC lifecycle tests for listener errors, TLS configuration,
+  operational hooks, metrics registration, and bounded shutdown.
+- Race-oriented tests for task storage, validation translator initialization,
+  request binding plans, provider authentication, and search reflection.
+- A compiled basic HTTP example and an architecture contract document.
 
 ### Changed
 
-#### Dependency Updates
-- Updated all Go module dependencies to latest stable versions
-- Enhanced compatibility with Go 1.21+
-- Improved security by addressing known vulnerabilities in dependencies
-- Optimized dependency tree for reduced binary size
-
-#### Error Handling
-- Unified error response format across all components
-- Enhanced error propagation with proper context preservation
-- Improved error logging with structured fields
-- Better error recovery mechanisms
-
-#### Action Scope Management
-- Refined scope boundaries for clearer operation isolation
-- Enhanced context passing between components
-- Improved resource cleanup and lifecycle management
-- Better integration with existing middleware stack
+- `Runnable.Start(context.Context) error` now has an explicit blocking lifecycle
+  contract. The manager concurrently runs registered components, cancels peers
+  on the first unexpected exit, and waits for bounded graceful shutdown.
+- HTTP servers now configure read-header, read, write, idle, and shutdown
+  timeouts and return listen/serve errors to the manager.
+- gRPC servers no longer terminate the process during TLS initialization,
+  mutate global tracing state, or panic on duplicate default metrics
+  registration. Reflection, metrics registry, connection timeout, and shutdown
+  timeout are configurable.
+- Task servers block until cancellation and wait for in-flight cron jobs. The
+  default task storage is concurrency-safe and returns deterministic key order.
+- Request binding uses a deterministic cached plan: URI and query/form values
+  are applied before one media-type-matched body, followed by one final
+  validation pass.
+- Validation translators are registered once before concurrent use.
+- GORM search uses one shared filter chain for rows and count, always applies
+  pagination, and returns initialization and row-iteration errors explicitly.
+- GORM, MGM, Kubernetes, and custom actions share the same per-action
+  authentication and middleware semantics.
 
 ### Fixed
 
-#### Stability Improvements
-- Resolved nil pointer dereference risks in core components
-- Fixed race conditions in concurrent operations
-- Addressed memory leaks in long-running services
-- Improved error handling in edge cases
-
-#### Performance Optimizations
-- Reduced memory allocation in hot paths
-- Optimized database query performance
-- Enhanced caching strategies for frequently accessed data
-- Improved response times for high-concurrency scenarios
+- Fixed the manager deadlock/error-loss lifecycle in which long-running
+  components could not be cancelled or background serve errors could be lost.
+- Fixed `grpc.WithTimeout` writing the keepalive field instead of the connection
+  timeout field.
+- Fixed GORM Search silently skipping request conditions and pagination when no
+  custom scope was configured.
+- Fixed `GET`, `HEAD`, and `OPTIONS` binding from attempting to consume JSON,
+  XML, or YAML request bodies.
+- Fixed Mongo/MGM controllers ignoring `WithAuth(true)`.
+- Fixed search reflection recursing into scalar pagination fields and panicking;
+  nil nested values, malformed `between` values, and `isnull` fields are now
+  handled safely.
+- Replaced library-level process exit on nil response context with a recoverable
+  programming-error panic.
 
 ### Security
 
-#### Security Enhancements
-- Strengthened input validation across all components
-- Enhanced authentication and authorization checks
-- Improved secret handling and storage
-- Added security headers to HTTP responses
+- Authentication-enabled controllers now fail closed when the compatibility
+  `response.AuthHandler` is missing, rather than registering an anonymous route.
+- HTTP servers have non-zero defensive I/O timeouts by default.
+- Invalid TLS configuration is returned to the embedding application as an
+  error instead of terminating the process.
 
-## [v0.7.0] - Previous Version
+### Compatibility
+
+- Custom `Runnable` implementations that previously launched a goroutine and
+  returned immediately must now block until their work stops. Returning early
+  is treated as an unexpected component exit.
+- HTTP and gRPC `Start` methods now block and report runtime errors.
+- GORM and MGM route naming retains the historical `mgm.CollName` behavior;
+  Kubernetes controllers without a database model use their resource type.
+- Correctness changes make previously ignored pagination, filters, and
+  authentication settings effective. Roll back this change set as a unit if an
+  application depended on the old unsafe behavior.
+
+### Documentation
+
+- Replaced stale repository links, nonexistent quick-start APIs, unsupported
+  version instructions, and unenforced coverage claims.
+- Removed historical free-form migration examples that referenced APIs not
+  present in the current module. Released source tags remain the authority for
+  older behavior.
+
+## v0.7.3 - 2026-06-07
 
 ### Added
-- Initial support for DynamoDB
-- Configuration provider framework
-- Istio tracing integration
-- Out-of-the-box service templates
 
-### Changed
-- Core architecture refactoring
-- Improved modularity and extensibility
-- Enhanced documentation structure
+- Structured GitHub issue forms and refreshed open-source contribution entry
+  points.
 
-### Removed
-- Deprecated legacy components
-- Insecure default configurations
+### Fixed
 
-## Migration Guide
-
-### From v0.7.0 to v0.7.1
-
-#### Error Handling Changes
-```go
-// Old (v0.7.0)
-if err != nil {
-    return err
-}
-
-// New (v0.7.1) - Use standardized error codes
-if err != nil {
-    return errors.Wrap(err, "operation_failed", errors.WithCode(errors.CodeInternal))
-}
-```
-
-#### Action Scope Usage
-```go
-// New in v0.7.1 - Context-aware operations
-ctx := action.NewContext(context.Background(), "user_operation")
-result, err := service.Process(ctx, request)
-```
-
-#### Dependency Updates
-Ensure your `go.mod` is updated:
-```go
-require github.com/mss-boot-io/mss-boot v0.7.1
-```
-
-Run dependency update:
-```bash
-go mod tidy
-```
-
-## Upgrade Instructions
-
-### Basic Upgrade
-```bash
-# Update go.mod
-go get github.com/mss-boot-io/mss-boot@v0.7.1
-
-# Tidy dependencies
-go mod tidy
-
-# Run tests to verify compatibility
-go test ./...
-```
-
-### Full Migration
-```bash
-# 1. Backup your current code
-cp -r my-service my-service-backup
-
-# 2. Update dependency
-go get github.com/mss-boot-io/mss-boot@v0.7.1
-
-# 3. Update error handling patterns
-#   - Replace custom error codes with standardized ones
-#   - Add action scopes to critical operations
-
-# 4. Run comprehensive tests
-go test ./... -coverprofile=coverage.out
-go test -tags=integration ./...
-
-# 5. Verify functionality
-#   - Test all critical user flows
-#   - Validate error scenarios
-#   - Check performance metrics
-```
-
-## Breaking Changes
-
-### Minimal Breaking Changes
-- **Error Code Structure**: Custom error codes should be migrated to standardized format
-- **Context Usage**: Consider adding action scopes for better operation tracking
-- **Dependency Updates**: Some third-party APIs may have minor breaking changes
-
-### Compatibility Notes
-- All existing APIs remain functional with warnings for deprecated patterns
-- Database schemas are backward compatible
-- Configuration formats remain unchanged
-
-## Known Issues
-
-### Current Limitations
-1. **Multi-tenant Support**: Still experimental, not recommended for production
-2. **Advanced Tracing**: Some tracing features require manual configuration
-3. **Edge Case Error Handling**: Rare edge cases may still produce generic errors
-
-### Workarounds
-- Use standardized error codes for all new development
-- Implement proper action scoping for complex operations
-- Monitor logs for any unexpected error patterns
-
-## Future Roadmap
-
-### Planned Features
-- **v0.8.0**: Enhanced multi-tenant support
-- **v0.8.0**: Advanced observability with OpenTelemetry
-- **v0.9.0**: Service mesh integration improvements
-- **v1.0.0**: Production-ready stability guarantee
-
-### Long-term Goals
-- Comprehensive testing suite with 90%+ coverage
-- Advanced security features including RBAC
-- Enhanced developer experience with better tooling
-- Expanded ecosystem with additional service templates
-
-## Contributors
-
-Thanks to all contributors who made v0.7.1 possible.
-
-## License
-
-MIT License - see [LICENSE](./LICENSE) for details.
+- Completed GORM query-cache tag invalidation for create, update, and delete
+  paths.
+- Validated MongoDB ObjectID input before delete operations.

--- a/mss-boot/CHANGELOG.md
+++ b/mss-boot/CHANGELOG.md
@@ -9,27 +9,32 @@ and the project uses semantic versioning for nested-module releases.
 ### Added
 
 - Blocking lifecycle regression tests for cancellation, peer-error propagation,
-  unexpected exits, graceful-shutdown deadlines, duplicate starts, and signal
-  ownership.
+  unexpected exits, graceful-shutdown deadlines, duplicate starts, shutdown
+  error collection, and signal ownership.
 - HTTP and gRPC lifecycle tests for listener errors, TLS configuration,
   operational hooks, metrics registration, and bounded shutdown.
-- Race-oriented tests for task storage, validation translator initialization,
-  request binding plans, provider authentication, and search reflection.
+- Race-oriented tests for task storage and shutdown, validation translator
+  initialization, request binding plans, provider authentication, and search
+  reflection.
 - A compiled basic HTTP example and an architecture contract document.
 
 ### Changed
 
 - `Runnable.Start(context.Context) error` now has an explicit blocking lifecycle
   contract. The manager concurrently runs registered components, cancels peers
-  on the first unexpected exit, and waits for bounded graceful shutdown.
+  on the first unexpected exit, joins component shutdown errors, and waits for
+  bounded graceful shutdown.
+- The manager's default outer shutdown deadline is 30 seconds so built-in
+  adapters can complete their shorter deadlines and return specific errors.
 - HTTP servers now configure read-header, read, write, idle, and shutdown
   timeouts and return listen/serve errors to the manager.
 - gRPC servers no longer terminate the process during TLS initialization,
   mutate global tracing state, or panic on duplicate default metrics
   registration. Reflection, metrics registry, connection timeout, and shutdown
   timeout are configurable.
-- Task servers block until cancellation and wait for in-flight cron jobs. The
-  default task storage is concurrency-safe and returns deterministic key order.
+- Task servers block until cancellation and wait for in-flight cron jobs up to a
+  configurable shutdown timeout. The default task storage is concurrency-safe
+  and returns deterministic key order.
 - Request binding uses a deterministic cached plan: URI and query/form values
   are applied before one media-type-matched body, followed by one final
   validation pass.
@@ -42,9 +47,12 @@ and the project uses semantic versioning for nested-module releases.
 ### Fixed
 
 - Fixed the manager deadlock/error-loss lifecycle in which long-running
-  components could not be cancelled or background serve errors could be lost.
+  components could not be cancelled, background serve errors could be lost, or
+  real flush/close errors returned during cancellation could be discarded.
 - Fixed `grpc.WithTimeout` writing the keepalive field instead of the connection
   timeout field.
+- Fixed task shutdown waiting forever for a blocked cron job; it now returns a
+  deadline error when its configured shutdown period expires.
 - Fixed GORM Search silently skipping request conditions and pagination when no
   custom scope was configured.
 - Fixed `GET`, `HEAD`, and `OPTIONS` binding from attempting to consume JSON,
@@ -55,6 +63,8 @@ and the project uses semantic versioning for nested-module releases.
   handled safely.
 - Replaced library-level process exit on nil response context with a recoverable
   programming-error panic.
+- Removed unused synchronization-bearing table-test fields that caused `go vet`
+  `copylocks` failures.
 
 ### Security
 
@@ -70,6 +80,8 @@ and the project uses semantic versioning for nested-module releases.
   returned immediately must now block until their work stops. Returning early
   is treated as an unexpected component exit.
 - HTTP and gRPC `Start` methods now block and report runtime errors.
+- Task `Start` can now return `context.DeadlineExceeded` when a running job
+  exceeds its shutdown timeout.
 - GORM and MGM route naming retains the historical `mgm.CollName` behavior;
   Kubernetes controllers without a database model use their resource type.
 - Correctness changes make previously ignored pagination, filters, and

--- a/mss-boot/README.Zh-cn.md
+++ b/mss-boot/README.Zh-cn.md
@@ -1,114 +1,146 @@
 # mss-boot
 
----
-<img align="right" width="32" src="https://docs.mss-boot-io.top/favicon.ico"  alt="https://github.com/mss-boot-io/mss-boot"/>
+[![CI](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/codeql.yml)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
+[English](./README.md) | 简体中文
 
-[![ci](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot/actions/workflows/scorecard.yml)
-[![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/releases)
-[![License](https://img.shields.io/github/license/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot/blob/main/LICENSE)
+`mss-boot` 是 [`mss-boot-admin`](https://github.com/mss-boot-io/mss-boot-admin)
+单仓中的可复用 Go 框架模块，提供统一管理的 HTTP、gRPC、定时任务运行时，以及配置、
+持久化、存储、安全和请求控制器适配能力。
 
-[English](https://github.com/mss-boot-io/mss-boot/blob/main/README.md) | 简体中文
+该目录仍保持独立 Go module，并通过 `GOWORK=off` 验证，避免仓库工作区掩盖依赖缺失。
 
-支持grpc、http协议的企业级语言异构微服务解决方案，单服务代码框架坚持极简的原则，同时提供完善的devops流程支撑(gitops)
+## 当前状态
 
-## 📦 当前版本: v0.7.3
+- Module 路径：`github.com/mss-boot-io/mss-boot-admin/mss-boot`
+- 源码目录：`mss-boot/`
+- Go 要求：Go 1.26 或更高版本
+- 稳定性：v1 之前；导出 API 属于兼容面，但正确性修复可能收紧过去含糊的行为
 
-[在线文档](https://docs.mss-boot-io.top)
-
-[贡献指南](./CONTRIBUTING.md) · [安全策略](./SECURITY.md) · [新手任务](https://github.com/mss-boot-io/mss-boot/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
-
-[微服务集合](https://github.com/mss-boot-io/mss-boot-monorepo)
-
-## ✨ 特性
-> - 遵循 RESTful API 设计规范
-> - 登录支持idp(dex)
-> - 支持 Swagger 文档(基于swaggo)
-> - AI 可读契约、发布治理与可观测能力
-> - 标准化错误处理与 Action Scope 上下文治理
-> - GORM 查询缓存标签失效、Mongo ObjectID 安全校验等稳定性增强
-> - 完善的cicd配套
-
-## todo list
-> - [ ] 支持租户
-> - [ ] 支持dynamodb
-> - [x] 支持config provider
-> - [ ] 支持istio链路追踪
-> - [ ] 开箱即用支持
-
-## 🧭 Action/Controller 术语
-
-mss-boot 的请求流程会反复出现以下概念：
-
-- **Controller**：实现 `pkg/response.Controller` 的控制器，负责路由路径、路由级 Gin handlers，以及按 action 名称取得具体 `Action`。`pkg/response/controller.Simple` 会根据 GORM、MGM 或 Kubernetes 模型 provider 选择对应 action。
-- **Action**：`get`、`search`、`control`、`delete` 等具名请求动作。Action 实现 `response.Action`，返回 Gin handler chain，并封装该动作在具体 provider 下的处理逻辑。
-- **Hook**：挂在生命周期节点上的回调，例如 `BeforeCreate`、`AfterUpdate`、`BeforeSearch`，配置源的 `PrefixHook` / `PostHook`，以及服务启动或关闭回调。
-- **Scope**：通常通过 `WithScope` 注入的按请求查询过滤器，会把当前 Gin context 和模型表转换成 GORM scope。常用于租户、归属关系或其他上下文约束。
-- **Provider**：用于选择后端实现的枚举或 `Stringer`。控制器常见的是 `ModelProviderGorm`、`ModelProviderMgm`、`ModelProviderK8S`；配置源与存储包也有各自的 provider。
-
-## 🧪 本地验证
-
-提交 PR 前建议先在仓库根目录运行：
+开发版本可使用 `main`；生产环境应替换为已发布的子模块标签或不可变提交：
 
 ```bash
-# 必须通过的本地测试入口
-go test ./...
-
-# 覆盖率报告
-go test ./... -coverprofile=coverage.out
-go tool cover -func=coverage.out
-
-# 集成测试，需要先配置对应外部服务
-go test -tags=integration ./...
+go get github.com/mss-boot-io/mss-boot-admin/mss-boot@main
 ```
 
-依赖数据库、对象存储、Kubernetes、云凭证或其他可选外部服务的集成类测试，在配置缺失时应主动 skip，而不是让普通本地验证失败。
+## 核心能力
 
-Lint 流程与 CI 保持一致：
+- 基于 Context 的 HTTP、gRPC、cron 生命周期管理
+- HTTP 运维路由、超时、TLS、指标和优雅关闭
+- gRPC 中间件、OpenTelemetry、Prometheus、TLS 和有界优雅关闭
+- GORM、MongoDB/MGM、Kubernetes 控制器 Action
+- 本地文件、数据库、对象存储、ConfigMap、Consul、AWS AppConfig 等配置源
+- 缓存、队列、对象存储、迁移、安全、语言和响应工具
+
+可选集成在未配置时必须返回错误或跳过；框架包不能直接终止宿主进程。
+
+## 运行时契约
+
+被管理组件实现：
+
+```go
+type Runnable interface {
+    fmt.Stringer
+    Start(context.Context) error
+}
+```
+
+`Start` 必须阻塞，直到组件停止、Context 被取消，或发生不可恢复的运行时错误；返回前必须
+释放自己持有的资源。Manager 并发运行组件，首个异常退出会取消同组组件，并在配置的时间内
+等待优雅关闭完成。
+
+为兼容现有应用，Manager 默认处理 `SIGINT` 和 `SIGTERM`。自行管理进程信号的应用应使用
+`server.WithoutSignalHandling()`，并传入由 `signal.NotifyContext` 创建的 Context。
+
+生命周期、绑定、鉴权、查询和兼容性细节见
+[运行时与请求契约](./docs/architecture/runtime-and-request-contracts.md)。
+
+## 快速开始
+
+完整示例位于 [`examples/basic-http/main.go`](./examples/basic-http/main.go)，并会随框架测试一起编译。
+
+```go
+package main
+
+import (
+    "context"
+    "log/slog"
+    "net/http"
+    "os"
+    "os/signal"
+    "syscall"
+
+    "github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server"
+    "github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server/listener"
+)
+
+func main() {
+    ctx, stop := signal.NotifyContext(
+        context.Background(),
+        os.Interrupt,
+        syscall.SIGTERM,
+    )
+    defer stop()
+
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+        _, _ = w.Write([]byte("ok\n"))
+    })
+
+    manager := server.New(server.WithoutSignalHandling())
+    manager.Add(listener.New(
+        listener.WithAddr(":8080"),
+        listener.WithHandler(mux),
+    ))
+
+    if err := manager.Start(ctx); err != nil {
+        slog.Error("server stopped unexpectedly", "error", err)
+        os.Exit(1)
+    }
+}
+```
+
+## 请求与控制器保证
+
+- 先绑定 URI 和 Query/Form，再按媒体类型最多读取一种 Body，最后只校验一次完整 DTO。
+- `GET`、`HEAD`、`OPTIONS` 不读取 JSON、XML、YAML Body。
+- GORM、MGM、Kubernetes 和自定义 Action 的 `WithAuth(true)` 均默认拒绝：全局兼容鉴权
+  Handler 缺失时返回服务配置错误，不能悄悄变成匿名接口。
+- GORM Search 必定应用请求条件和分页；Count 使用同样过滤条件但不带分页。
+- Search 反射遇到不支持的 DTO 字段时安全忽略，不再 panic。
+
+## 验证
+
+在仓库根目录执行：
 
 ```bash
-# 未安装工具时先安装
-go install golang.org/x/tools/cmd/goimports@latest
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-
-# 本地 lint 扫描
-golangci-lint run ./...
+make deps-framework
+make test-framework
 ```
 
-GitHub Actions 会在仓库根目录运行 action 提供的 latest `golangci-lint`。如果本地二进制由低于 `go.mod` 目标版本的 Go 构建，请先重新安装再扫描。当前 lint job 用于提示历史 lint backlog，`go test ./...` 仍是必须通过的 CI 检查。
+独立模块、竞态和静态检查：
 
-## 🔧 快速开始
-
-### 环境要求
-- Go 1.26+
-
-### 使用 Go Modules
 ```bash
-go get github.com/mss-boot-io/mss-boot-admin/mss-boot@v0.8.0
+cd mss-boot
+GOWORK=off go test -race -shuffle=on -count=1 ./...
+GOWORK=off go vet ./...
+GOWORK=off go mod tidy
+git diff --exit-code -- go.mod go.sum
 ```
 
-### 本地检查
-```bash
-make tidy
-make test
-make coverage
-make lint
-```
+依赖可选数据库、对象存储、Kubernetes 集群或云凭证的测试，在未配置时必须主动跳过。
+在 CI 真正执行覆盖率阈值前，README 不声明未经证明的覆盖率数字。
 
-## 请我喝杯咖啡
-<a href="https://www.buymeacoffee.com/lwnmengjing" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+## 兼容与发布
 
+框架仍处于 v1 之前。任何改变可观察行为的变更都必须包含测试、文档、安全影响，以及迁移或
+回滚说明。子模块发布标签应采用 `mss-boot/vX.Y.Z`。
 
-## JetBrains 开源证书支持
+更多信息见 [CHANGELOG.md](./CHANGELOG.md)、[CONTRIBUTING.md](./CONTRIBUTING.md)
+和 [SECURITY.md](./SECURITY.md)。
 
-`mss-boot-io` 项目一直以来都是在 JetBrains 公司旗下的 GoLand 集成开发环境中进行开发，基于 **free JetBrains Open Source license(s)** 正版免费授权，在此表达我的谢意。
+## License
 
-<a href="https://www.jetbrains.com/?from=kubeadm-ha" target="_blank"><img src="https://raw.githubusercontent.com/panjf2000/illustrations/master/jetbrains/jetbrains-variant-4.png" width="250" align="middle"/></a>
-
-## 🔑 License
-
-[MIT](https://raw.githubusercontent.com/mss-boot-io/mss-boot/main/LICENSE)
-
-Copyright (c) 2022 mss-boot-io
+[MIT](./LICENSE)

--- a/mss-boot/README.md
+++ b/mss-boot/README.md
@@ -1,175 +1,162 @@
 # mss-boot
 
----
-<img align="right" width="320" src="https://docs.mss-boot-io.top/favicon.ico"  alt="https://github.com/mss-boot-io/mss-boot-admin/mss-boot"/>
+[![CI](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/actions/workflows/codeql.yml)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
+English | [简体中文](./README.Zh-cn.md)
 
-[![ci](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/actions/workflows/scorecard.yml)
-[![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/releases)
-[![License](https://img.shields.io/github/license/mss-boot-io/mss-boot.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/blob/main/LICENSE)
+`mss-boot` is the reusable Go framework module inside the
+[`mss-boot-admin`](https://github.com/mss-boot-io/mss-boot-admin) monorepo. It
+provides managed HTTP, gRPC, and scheduled-task runtimes together with common
+configuration, persistence, storage, security, and request-controller adapters.
 
-English | [简体中文](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/blob/main/README.Zh-cn.md)
+The module remains independently consumable and is validated with `GOWORK=off`
+to prevent the repository workspace from hiding missing dependencies.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/mss-boot-io/mss-boot)
+## Status
 
-An enterprise-level language heterogeneous microservice solution that supports grpc and http protocols. The single-service code framework adheres to the principle of minimalism, while providing complete devops process support (gitops).
+- Module path: `github.com/mss-boot-io/mss-boot-admin/mss-boot`
+- Source directory: `mss-boot/`
+- Go requirement: Go 1.26 or later
+- Stability: pre-v1; exported APIs are compatibility surfaces, but correctness
+  fixes may tighten previously ambiguous behavior
 
-## 📦 Latest Version: v0.7.3
+For a development build, use `main`; for production, replace it with a released
+nested-module tag or an immutable commit:
 
-[documentation](https://docs.mss-boot-io.top)
-
-[contributing](./CONTRIBUTING.md) · [security](./SECURITY.md) · [good first issues](https://github.com/mss-boot-io/mss-boot-admin/mss-boot/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
-
-[http service template](https://github.com/mss-boot-io/service-http)
-
-[grpc service template](https://github.com/mss-boot-io/service-grpc)
-
-## ✨ Features
-> - Follow RESTful API Design Specifications
-> - Login support idp(dex)
-> - Support for Swagger documentation (based on swaggo)
-> - Code generation tool
-> - Perfect cicd package
-> - Comprehensive core libraries (log, cache, queue, search, config)
-> - Multi-database support (MySQL, PostgreSQL, SQLite, MongoDB)
-> - Multi-storage provider support (local, S3, embed)
-> - Advanced error handling with standardized error codes
-> - Action scope management for context-aware operations
-> - Extensive middleware ecosystem
-
-## 🚀 v0.7.x Highlights
-
-### Core Improvements
-- **Enhanced Error Handling**: Standardized error codes and improved error propagation
-- **Action Scope Management**: Better context management for complex operations
-- **Query Cache Invalidation**: More complete GORM query-cache tag invalidation for create, update, and delete paths
-- **Mongo Safety**: ObjectID validation before Mongo delete operations
-- **Dependency Updates**: Comprehensive dependency refresh across all modules
-- **Performance Optimizations**: Improved memory usage and response times
-
-### Testing & Quality
-- **Test Coverage**: Comprehensive test suite with 80%+ coverage requirement
-- **Integration Testing**: Robust integration tests for all core components
-- **CI/CD Pipeline**: Enhanced GitHub Actions workflow with quality gates
-- **Open Source Intake**: Structured issue forms and refreshed contributor entry points
-
-### Documentation
-- **Comprehensive Guides**: Updated documentation for all core features
-- **API Reference**: Complete Swagger documentation for all endpoints
-- **Migration Guides**: Clear upgrade paths from previous versions
-
-## 🧭 Action/Controller Glossary
-
-The request flow uses a small set of repeated terms:
-
-- **Controller**: A `pkg/response.Controller` implementation that owns a route path, route-level Gin handlers, and the mapping from an action name to a concrete `Action`. `pkg/response/controller.Simple` chooses provider-specific actions for GORM, MGM, or Kubernetes models.
-- **Action**: A named request operation such as `get`, `search`, `control`, or `delete`. An action implements `response.Action`, returns a Gin handler chain, and contains the provider-specific logic for handling that operation.
-- **Hook**: A callback attached to a lifecycle point. Common examples are `BeforeCreate`, `AfterUpdate`, `BeforeSearch`, config source `PrefixHook` / `PostHook`, and server start or shutdown hooks.
-- **Scope**: A per-request query filter, usually supplied through `WithScope`, that turns the current Gin context and model table into a GORM scope. Use scopes for tenant filters, ownership filters, or other contextual constraints.
-- **Provider**: The selected backend implementation for a model, config source, or storage target. For controllers this is usually `ModelProviderGorm`, `ModelProviderMgm`, or `ModelProviderK8S`; config and storage packages have their own provider enums.
-
-## 📋 Todo List
-> - [x] Support dynamodb
-> - [x] Support config provider  
-> - [x] Support istio traces
-> - [x] Out-of-the-box support
-> - [x] Enhanced error handling (v0.7.x)
-> - [x] Action scope management (v0.7.x)
-> - [x] Comprehensive testing infrastructure (v0.7.x)
-
-## 🧪 Testing
-
-The project follows strict testing requirements:
-
-### Test Types
-- **Unit Tests**: `*_test.go` files alongside source code
-- **Integration Tests**: Database and API integration validation  
-- **E2E Tests**: Full stack testing with real dependencies
-
-### Coverage Requirements
-- **Minimum Coverage**: 80%
-- **Critical Components**: 85%+
-- **New Code**: Must meet or exceed existing coverage
-
-### Running Tests
 ```bash
-# Required local test gate
-go test ./...
-
-# Coverage report
-go test ./... -coverprofile=coverage.out
-go tool cover -func=coverage.out
-
-# Integration tests (requires configured external services)
-go test -tags=integration ./...
+go get github.com/mss-boot-io/mss-boot-admin/mss-boot@main
 ```
 
-Integration-style tests should skip when optional databases, object storage, Kubernetes clusters, cloud credentials, or other external services are not configured.
+## Capabilities
 
-### Running Lint
-```bash
-# Install the tools used by the CI lint job when they are not already available
-go install golang.org/x/tools/cmd/goimports@latest
-go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+- Context-driven lifecycle management for HTTP, gRPC, and cron components
+- HTTP operational endpoints, timeouts, TLS, metrics, and graceful shutdown
+- gRPC middleware, OpenTelemetry integration, Prometheus metrics, TLS, and
+  bounded graceful shutdown
+- GORM, MongoDB/MGM, and Kubernetes controller actions
+- Configuration sources including local files, databases, object storage,
+  Kubernetes ConfigMaps, Consul, and AWS AppConfig
+- Cache, queue, object-storage, migration, security, language, and response
+  helpers
 
-# Local lint sweep
-golangci-lint run ./...
+Optional integrations must return errors or skip when unconfigured; framework
+packages must not terminate the embedding process.
+
+## Runtime contract
+
+A managed component implements:
+
+```go
+type Runnable interface {
+    fmt.Stringer
+    Start(context.Context) error
+}
 ```
 
-The GitHub Actions lint job runs `golangci-lint` from the repository root with the latest action-provided version. If a local binary was built with an older Go version than `go.mod` targets, reinstall it before running the sweep. The lint job is currently advisory while the existing lint backlog is reduced; `go test ./...` remains the required CI gate.
+`Start` must block until the component stops, its context is cancelled, or an
+unrecoverable runtime error occurs. It must release owned resources before
+returning. The manager runs components concurrently, cancels peers on the first
+unexpected exit, and waits for graceful shutdown up to the configured timeout.
 
-## 🔧 Quick Start
+The manager handles `SIGINT` and `SIGTERM` by default for compatibility. An
+application that owns process signals should use `server.WithoutSignalHandling()`
+and pass a context created by `signal.NotifyContext`.
 
-### Requirements
-- Go 1.26+
+See [Runtime and request contracts](./docs/architecture/runtime-and-request-contracts.md)
+for lifecycle, binding, authentication, query, and compatibility details.
 
-### Using Go Modules
-```bash
-go get github.com/mss-boot-io/mss-boot-admin/mss-boot@v0.8.0
-```
+## Quick start
 
-### Basic Usage
+The complete example is compiled as part of the framework test suite:
+[`examples/basic-http/main.go`](./examples/basic-http/main.go).
+
 ```go
 package main
 
 import (
+    "context"
+    "log/slog"
+    "net/http"
+    "os"
+    "os/signal"
+    "syscall"
+
     "github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server"
-    "github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/log"
+    "github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server/listener"
 )
 
 func main() {
-    s := server.New()
-    if err := s.Run(); err != nil {
-        log.Fatal("server run failed", log.Err(err))
+    ctx, stop := signal.NotifyContext(
+        context.Background(),
+        os.Interrupt,
+        syscall.SIGTERM,
+    )
+    defer stop()
+
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+        _, _ = w.Write([]byte("ok\n"))
+    })
+
+    manager := server.New(server.WithoutSignalHandling())
+    manager.Add(listener.New(
+        listener.WithAddr(":8080"),
+        listener.WithHandler(mux),
+    ))
+
+    if err := manager.Start(ctx); err != nil {
+        slog.Error("server stopped unexpectedly", "error", err)
+        os.Exit(1)
     }
 }
 ```
 
-### Local Checks
+## Request and controller guarantees
+
+- URI and query/form values are bound before at most one media-type-matched
+  request body; the completed DTO is validated once.
+- `GET`, `HEAD`, and `OPTIONS` requests never consume JSON, XML, or YAML bodies.
+- `WithAuth(true)` is fail-closed for GORM, MGM, Kubernetes, and custom actions.
+  If the global compatibility handler is missing, the request is rejected as a
+  server configuration error rather than becoming anonymous.
+- GORM search always applies request conditions and pagination. Count queries
+  use the same filters without pagination.
+- Search reflection ignores unsupported DTO fields instead of panicking.
+
+## Validation
+
+From the repository root:
+
 ```bash
-make tidy
-make test
-make coverage
-make lint
+make deps-framework
+make test-framework
 ```
 
-## 📝 CHANGELOG
+For an independent, race-tested framework check:
 
-For detailed release notes and migration guides, see [CHANGELOG.md](./CHANGELOG.md).
+```bash
+cd mss-boot
+GOWORK=off go test -race -shuffle=on -count=1 ./...
+GOWORK=off go vet ./...
+GOWORK=off go mod tidy
+git diff --exit-code -- go.mod go.sum
+```
 
-## Buy me a coffee
-<a href="https://www.buymeacoffee.com/lwnmengjing" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+Tests that require optional databases, object storage, Kubernetes clusters, or
+cloud credentials must skip when those integrations are not configured. No
+coverage percentage is claimed until CI enforces the same threshold.
 
-## JetBrains open source certificate support
+## Compatibility and releases
 
-The `mss-boot-io` project has always been developed in the GoLand integrated development environment under JetBrains, based on the **free JetBrains Open Source license(s)** genuine free license. I would like to express my gratitude.
+The module is pre-v1. Changes that alter observable behavior must include tests,
+documentation, security impact, and migration or rollback notes. Nested-module
+releases should use tags in the form `mss-boot/vX.Y.Z`.
 
-<a href="https://www.jetbrains.com/?from=kubeadm-ha" target="_blank"><img src="https://raw.githubusercontent.com/panjf2000/illustrations/master/jetbrains/jetbrains-variant-4.png" width="250" align="middle"/></a>
+See [CHANGELOG.md](./CHANGELOG.md), [CONTRIBUTING.md](./CONTRIBUTING.md), and
+[SECURITY.md](./SECURITY.md).
 
-## 🔑 License
+## License
 
-[MIT](https://raw.githubusercontent.com/mss-boot-io/mss-boot/main/LICENSE)
-
-Copyright (c) 2022 mss-boot-io
+[MIT](./LICENSE)

--- a/mss-boot/core/server/grpc/options.go
+++ b/mss-boot/core/server/grpc/options.go
@@ -1,12 +1,5 @@
 package grpc
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/2 4:30 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/2 4:30 下午
- */
-
 import (
 	"context"
 	"crypto/tls"
@@ -20,7 +13,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -35,6 +27,7 @@ const (
 	defaultConnectionIdleTime          = 10 * time.Second
 	defaultMaxServerConnectionAgeGrace = 10 * time.Second
 	defaultMiniKeepAliveTimeRate       = 2
+	defaultShutdownTimeout             = 10 * time.Second
 )
 
 var (
@@ -47,10 +40,10 @@ var (
 	}
 )
 
-// Option set options
+// Option configures a gRPC server.
 type Option func(*Options)
 
-// Options options
+// Options controls transport, middleware, observability, and lifecycle.
 type Options struct {
 	id                       string
 	domain                   string
@@ -61,6 +54,7 @@ type Options struct {
 	tls                      *tls.Config
 	keepAlive                time.Duration
 	timeout                  time.Duration
+	shutdownTimeout          time.Duration
 	maxConnectionAge         time.Duration
 	maxConnectionAgeGrace    time.Duration
 	maxConcurrentStreams     int
@@ -68,149 +62,171 @@ type Options struct {
 	unaryServerInterceptors  []grpc.UnaryServerInterceptor
 	streamServerInterceptors []grpc.StreamServerInterceptor
 	ctx                      context.Context
-	metrcsServer             *grpcprom.ServerMetrics
+	metricsServer            *grpcprom.ServerMetrics
+	metricsRegisterer        prometheus.Registerer
+	reflection               bool
 }
 
-// WithContext set ContextOption
+// WithContext adds a secondary lifecycle context. The server stops when either
+// this context or the context passed to Start is cancelled.
 func WithContext(c context.Context) Option {
 	return func(o *Options) {
 		o.ctx = c
 	}
 }
 
-// WithID set IDOption
+// WithID sets a logical server ID.
 func WithID(s string) Option {
 	return func(o *Options) {
 		o.id = s
 	}
 }
 
-// WithDomain set DomainOption
+// WithDomain sets a logical server domain.
 func WithDomain(s string) Option {
 	return func(o *Options) {
 		o.domain = s
 	}
 }
 
-// WithAddr set AddrOption
+// WithAddr sets the listen address.
 func WithAddr(s string) Option {
 	return func(o *Options) {
 		o.addr = s
 	}
 }
 
-// WithStartedHook 设置启动回调函数
+// WithStartedHook registers a callback invoked after the serve loop starts.
 func WithStartedHook(f func()) Option {
 	return func(o *Options) {
 		o.startedHook = f
 	}
 }
 
-// WithCert 设置cert
+// WithCert sets the TLS certificate path.
 func WithCert(s string) Option {
 	return func(o *Options) {
 		o.certFile = s
 	}
 }
 
-// WithKey 设置key
+// WithKey sets the TLS private-key path.
 func WithKey(s string) Option {
 	return func(o *Options) {
 		o.keyFile = s
 	}
 }
 
-// WithTLS set TlsOption
-func WithTLS(tls *tls.Config) Option {
+// WithTLS sets an in-memory TLS configuration. It takes precedence over
+// certificate and key file options.
+func WithTLS(config *tls.Config) Option {
 	return func(o *Options) {
-		o.tls = tls
+		o.tls = config
 	}
 }
 
-// WithKeepAlive set KeepAliveOption
+// WithKeepAlive sets the server keepalive interval.
 func WithKeepAlive(t time.Duration) Option {
 	return func(o *Options) {
 		o.keepAlive = t
 	}
 }
 
-// WithTimeout set TimeoutOption
+// WithTimeout sets the gRPC connection and keepalive timeout.
 func WithTimeout(t time.Duration) Option {
 	return func(o *Options) {
-		o.keepAlive = t
+		o.timeout = t
 	}
 }
 
-// WithMaxConnectionAge set MaxConnectionAgeOption
+// WithShutdownTimeout limits graceful shutdown before Stop is used. A
+// non-positive duration waits without a timeout.
+func WithShutdownTimeout(t time.Duration) Option {
+	return func(o *Options) {
+		o.shutdownTimeout = t
+	}
+}
+
+// WithReflection controls registration of the gRPC reflection service.
+func WithReflection(enabled bool) Option {
+	return func(o *Options) {
+		o.reflection = enabled
+	}
+}
+
+// WithPrometheusRegisterer changes the Prometheus registry used for the default
+// gRPC metrics collector. A nil registerer disables collector registration.
+func WithPrometheusRegisterer(registerer prometheus.Registerer) Option {
+	return func(o *Options) {
+		o.metricsRegisterer = registerer
+	}
+}
+
+// WithMaxConnectionAge sets the maximum connection age.
 func WithMaxConnectionAge(t time.Duration) Option {
 	return func(o *Options) {
 		o.maxConnectionAge = t
 	}
 }
 
-// WithMaxConnectionAgeGrace set MaxConnectionAgeGraceOption
+// WithMaxConnectionAgeGrace sets the grace period after maximum connection age.
 func WithMaxConnectionAgeGrace(t time.Duration) Option {
 	return func(o *Options) {
 		o.maxConnectionAgeGrace = t
 	}
 }
 
-// WithMaxConcurrentStreamsOption set MaxConcurrentStreamsOption
+// WithMaxConcurrentStreamsOption sets the maximum concurrent stream count.
 func WithMaxConcurrentStreamsOption(i int) Option {
 	return func(o *Options) {
 		o.maxConcurrentStreams = i
 	}
 }
 
-// WithMaxMsgSizeOption set MaxMsgSizeOption
+// WithMaxMsgSizeOption sets the maximum received message size.
 func WithMaxMsgSizeOption(i int) Option {
 	return func(o *Options) {
 		o.maxMsgSize = i
 	}
 }
 
-// WithUnaryServerInterceptors set UnaryServerInterceptorsOption
-func WithUnaryServerInterceptors(u ...grpc.UnaryServerInterceptor) Option {
+// WithUnaryServerInterceptors appends unary server interceptors.
+func WithUnaryServerInterceptors(interceptors ...grpc.UnaryServerInterceptor) Option {
 	return func(o *Options) {
-		if o.unaryServerInterceptors == nil {
-			o.unaryServerInterceptors = make([]grpc.UnaryServerInterceptor, 0)
-		}
-		o.unaryServerInterceptors = append(o.unaryServerInterceptors, u...)
+		o.unaryServerInterceptors = append(o.unaryServerInterceptors, interceptors...)
 	}
 }
 
-// WithStreamServerInterceptors set StreamServerInterceptorsOption
-func WithStreamServerInterceptors(u ...grpc.StreamServerInterceptor) Option {
+// WithStreamServerInterceptors appends stream server interceptors.
+func WithStreamServerInterceptors(interceptors ...grpc.StreamServerInterceptor) Option {
 	return func(o *Options) {
-		if o.streamServerInterceptors == nil {
-			o.streamServerInterceptors = make([]grpc.StreamServerInterceptor, 0)
-		}
-		o.streamServerInterceptors = append(o.streamServerInterceptors, u...)
+		o.streamServerInterceptors = append(o.streamServerInterceptors, interceptors...)
 	}
 }
 
 func defaultOptions() *Options {
-	reg := prometheus.NewRegistry()
-	reg.MustRegister(defaultMetricsServer)
-	// Setup metric for panic recoveries.
-	panicsTotal := promauto.With(reg).NewCounter(prometheus.CounterOpts{
+	panicsTotal := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "grpc_req_panics_recovered_total",
 		Help: "Total number of gRPC requests recovered from internal panic.",
 	})
-	grpcPanicRecoveryHandler := func(p any) (err error) {
+	grpcPanicRecoveryHandler := func(p any) error {
 		panicsTotal.Inc()
-		slog.Error("msg", "recovered from panic", "panic", p, "stack", debug.Stack())
-		return status.Errorf(codes.Internal, "%s", p)
+		slog.Error("recovered from gRPC panic", "panic", p, "stack", string(debug.Stack()))
+		return status.Error(codes.Internal, "internal server error")
 	}
+
 	return &Options{
 		addr:                  ":0",
 		keepAlive:             defaultKeepAliveTime,
 		timeout:               defaultConnectionIdleTime,
+		shutdownTimeout:       defaultShutdownTimeout,
 		maxConnectionAge:      infinity,
 		maxConnectionAgeGrace: defaultMaxServerConnectionAgeGrace,
 		maxConcurrentStreams:  defaultMaxConcurrentStreams,
 		maxMsgSize:            defaultMaxMsgSize,
-		metrcsServer:          defaultMetricsServer,
+		metricsServer:         defaultMetricsServer,
+		metricsRegisterer:     prometheus.DefaultRegisterer,
+		reflection:            true,
 		unaryServerInterceptors: []grpc.UnaryServerInterceptor{
 			logging.UnaryServerInterceptor(InterceptorLogger(slog.Default()), logging.WithFieldsFromContext(logTraceID)),
 			defaultMetricsServer.UnaryServerInterceptor(),
@@ -224,18 +240,18 @@ func defaultOptions() *Options {
 	}
 }
 
-// customRecovery custom recovery
+// customRecovery creates a domain-aware recovery handler for callers that need
+// to preserve the historical error shape.
 func customRecovery(id, domain string) recovery.RecoveryHandlerFunc {
-	return func(p interface{}) (err error) {
-		slog.Error(fmt.Sprintf("panic triggered: %v", p))
+	return func(p interface{}) error {
+		slog.Error("gRPC panic triggered", "panic", p, "id", id, "domain", domain)
 		return fmt.Errorf("%s[%s] panic triggered: %v", id, domain, p)
 	}
 }
 
-// InterceptorLogger adapts slog logger to interceptor logger.
-// This code is simple enough to be copied and not imported.
-func InterceptorLogger(l *slog.Logger) logging.Logger {
-	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		l.Log(ctx, slog.Level(lvl), msg, fields...)
+// InterceptorLogger adapts slog.Logger to the middleware logging interface.
+func InterceptorLogger(logger *slog.Logger) logging.Logger {
+	return logging.LoggerFunc(func(ctx context.Context, level logging.Level, msg string, fields ...any) {
+		logger.Log(ctx, slog.Level(level), msg, fields...)
 	})
 }

--- a/mss-boot/core/server/grpc/server.go
+++ b/mss-boot/core/server/grpc/server.go
@@ -1,42 +1,39 @@
 package grpc
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/2 4:26 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/2 4:26 下午
- */
-
 import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"net"
-	"os"
 	"sync"
 
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server"
-
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )
 
-// Server server
+var (
+	// ErrAlreadyStarted is returned when a gRPC server is started twice.
+	ErrAlreadyStarted = errors.New("gRPC server has already been started")
+	// ErrIncompleteTLSConfiguration is returned when only one TLS file is set.
+	ErrIncompleteTLSConfiguration = errors.New("both TLS certificate and key files are required")
+)
+
+// Server is a managed gRPC server.
 type Server struct {
 	name    string
 	srv     *grpc.Server
 	mux     sync.Mutex
 	started bool
 	options Options
+	initErr error
 }
 
-// New grpc server
+// New creates a gRPC server and records initialization errors for Start.
 func New(name string, options ...Option) *Server {
 	s := &Server{name: name}
 	s.Options(options...)
@@ -44,40 +41,141 @@ func New(name string, options ...Option) *Server {
 	return s
 }
 
-// String string
+// String returns the server name.
 func (e *Server) String() string {
 	return e.name
 }
 
-// Options set options
+// Options resets defaults and applies options.
 func (e *Server) Options(options ...Option) {
 	e.options = *defaultOptions()
-	for _, o := range options {
-		o(&e.options)
+	for _, option := range options {
+		if option != nil {
+			option(&e.options)
+		}
 	}
 }
 
-// Server return server
+// Server returns the underlying gRPC server.
 func (e *Server) Server() *grpc.Server {
 	return e.srv
 }
 
-// NewServer new a server
+// NewServer rebuilds the underlying gRPC server. Initialization failures are
+// returned later by Start so the historical constructor remains source
+// compatible.
 func (e *Server) NewServer() {
-	grpc.EnableTracing = true
-	e.srv = grpc.NewServer(e.initGrpcServerOptions()...)
-	prometheus.MustRegister(e.options.metrcsServer)
-	e.options.metrcsServer.InitializeMetrics(e.srv)
-	reflection.Register(e.srv)
+	e.srv, e.initErr = e.buildServer()
 }
 
-// Register register
-func (e *Server) Register(do func(server *Server)) {
-	do(e)
+// Register invokes a service registration callback when initialization
+// succeeded. Start still reports any initialization failure.
+func (e *Server) Register(register func(server *Server)) {
+	if register != nil && e.srv != nil {
+		register(e)
+	}
 }
 
-func (e *Server) initGrpcServerOptions() []grpc.ServerOption {
-	opts := []grpc.ServerOption{
+// Start listens and blocks until the gRPC server exits or its lifecycle context
+// is cancelled.
+func (e *Server) Start(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, stop := mergeContexts(ctx, e.options.ctx)
+	defer stop()
+
+	e.mux.Lock()
+	if e.started {
+		e.mux.Unlock()
+		return ErrAlreadyStarted
+	}
+	if e.initErr != nil {
+		e.mux.Unlock()
+		return e.initErr
+	}
+	if e.srv == nil {
+		e.mux.Unlock()
+		return errors.New("gRPC server is not initialized")
+	}
+
+	listener, err := net.Listen("tcp", e.options.addr)
+	if err != nil {
+		e.mux.Unlock()
+		return fmt.Errorf("gRPC server listening on %s failed: %w", e.options.addr, err)
+	}
+	e.started = true
+	srv := e.srv
+	e.mux.Unlock()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(listener)
+	}()
+
+	if e.options.startedHook != nil {
+		e.options.startedHook()
+	}
+	server.PrintRunningInfo(listener.Addr().String(), "grpc")
+
+	select {
+	case err := <-serveErr:
+		return normalizeServeError(err)
+	case <-ctx.Done():
+		shutdownErr := e.shutdownWithTimeout()
+		return errors.Join(shutdownErr, normalizeServeError(<-serveErr))
+	}
+}
+
+// Shutdown gracefully stops the server and forcefully stops it when ctx ends.
+func (e *Server) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.mux.Lock()
+	srv := e.srv
+	e.mux.Unlock()
+	if srv == nil {
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		srv.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		srv.Stop()
+		<-done
+		return ctx.Err()
+	}
+}
+
+func (e *Server) buildServer() (*grpc.Server, error) {
+	options, err := e.initGrpcServerOptions()
+	if err != nil {
+		return nil, err
+	}
+	if err := registerCollector(e.options.metricsRegisterer, e.options.metricsServer); err != nil {
+		return nil, fmt.Errorf("register gRPC metrics: %w", err)
+	}
+
+	srv := grpc.NewServer(options...)
+	if e.options.metricsServer != nil {
+		e.options.metricsServer.InitializeMetrics(srv)
+	}
+	if e.options.reflection {
+		reflection.Register(srv)
+	}
+	return srv, nil
+}
+
+func (e *Server) initGrpcServerOptions() ([]grpc.ServerOption, error) {
+	options := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ConnectionTimeout(e.options.timeout),
 		grpc.ChainUnaryInterceptor(e.options.unaryServerInterceptors...),
@@ -94,58 +192,62 @@ func (e *Server) initGrpcServerOptions() []grpc.ServerOption {
 			MaxConnectionAgeGrace: e.options.maxConnectionAgeGrace,
 		}),
 	}
-	if e.options.certFile != "" && e.options.keyFile != "" {
+
+	if e.options.tls != nil {
+		options = append(options, grpc.Creds(credentials.NewTLS(e.options.tls.Clone())))
+		return options, nil
+	}
+	if (e.options.certFile == "") != (e.options.keyFile == "") {
+		return nil, ErrIncompleteTLSConfiguration
+	}
+	if e.options.certFile != "" {
 		creds, err := credentials.NewServerTLSFromFile(e.options.certFile, e.options.keyFile)
 		if err != nil {
-			slog.Error("Failed to generate credentials", slog.Any("err", err))
-			os.Exit(-1)
+			return nil, fmt.Errorf("load gRPC TLS credentials: %w", err)
 		}
-		opts = append(opts, grpc.Creds(creds))
+		options = append(options, grpc.Creds(creds))
 	}
-	return opts
+	return options, nil
 }
 
-// Start run
-func (e *Server) Start(ctx context.Context) error {
-	e.mux.Lock()
-	defer e.mux.Unlock()
-
-	if e.started {
-		return errors.New("gRPC Server was started more than once. " +
-			"This is likely to be caused by being added to a manage multiple times")
+func (e *Server) shutdownWithTimeout() error {
+	if e.options.shutdownTimeout <= 0 {
+		return e.Shutdown(context.Background())
 	}
-	// Set the internal context
-	if e.options.ctx != nil {
-		ctx = e.options.ctx
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), e.options.shutdownTimeout)
+	defer cancel()
+	return e.Shutdown(ctx)
+}
 
-	ts, err := net.Listen("tcp", e.options.addr)
-	if err != nil {
-		return fmt.Errorf("gRPC Server listening on %s failed: %w", e.options.addr, err)
+func normalizeServeError(err error) error {
+	if err == nil || errors.Is(err, grpc.ErrServerStopped) {
+		return nil
 	}
-	//log.Printf("gRPC Server listening on %s\n", ts.Addr().String())
-	e.started = true
+	return err
+}
 
-	go func() {
-		if err = e.srv.Serve(ts); err != nil {
-			slog.ErrorContext(ctx, "gRPC Server start error", slog.Any("err", err))
+func registerCollector(registerer prometheus.Registerer, collector prometheus.Collector) error {
+	if registerer == nil || collector == nil {
+		return nil
+	}
+	if err := registerer.Register(collector); err != nil {
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if errors.As(err, &alreadyRegistered) {
+			return nil
 		}
-		<-ctx.Done()
-		err = e.Shutdown(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, "gRPC Server shutdown error", slog.Any("err", err))
-		}
-	}()
-	if e.options.startedHook != nil {
-		e.options.startedHook()
+		return err
 	}
-	server.PrintRunningInfo(e.options.addr, "grpc")
 	return nil
 }
 
-// Shutdown shutdown
-func (e *Server) Shutdown(ctx context.Context) error {
-	slog.InfoContext(ctx, "gRPC Server will be shutdown gracefully")
-	e.srv.GracefulStop()
-	return nil
+func mergeContexts(primary, secondary context.Context) (context.Context, context.CancelFunc) {
+	if secondary == nil {
+		return context.WithCancel(primary)
+	}
+	ctx, cancel := context.WithCancel(primary)
+	stopSecondary := context.AfterFunc(secondary, cancel)
+	return ctx, func() {
+		stopSecondary()
+		cancel()
+	}
 }

--- a/mss-boot/core/server/grpc/server_test.go
+++ b/mss-boot/core/server/grpc/server_test.go
@@ -1,0 +1,122 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestWithTimeoutSetsConnectionTimeout(t *testing.T) {
+	options := defaultOptions()
+	keepAlive := options.keepAlive
+	WithTimeout(7 * time.Second)(options)
+	if options.timeout != 7*time.Second {
+		t.Fatalf("timeout = %s, want 7s", options.timeout)
+	}
+	if options.keepAlive != keepAlive {
+		t.Fatalf("WithTimeout changed keepalive from %s to %s", keepAlive, options.keepAlive)
+	}
+}
+
+func TestMultipleServersCanShareMetricsRegistry(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	first := New("first", WithPrometheusRegisterer(registry), WithReflection(false))
+	second := New("second", WithPrometheusRegisterer(registry), WithReflection(false))
+	if first.initErr != nil {
+		t.Fatalf("first server initialization failed: %v", first.initErr)
+	}
+	if second.initErr != nil {
+		t.Fatalf("second server initialization failed: %v", second.initErr)
+	}
+}
+
+func TestStartBlocksUntilCancellation(t *testing.T) {
+	started := make(chan struct{})
+	srv := New(
+		"test",
+		WithAddr("127.0.0.1:0"),
+		WithReflection(false),
+		WithPrometheusRegisterer(prometheus.NewRegistry()),
+		WithStartedHook(func() { close(started) }),
+		WithShutdownTimeout(time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Start(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("gRPC server did not start")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned before cancellation: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("graceful shutdown failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gRPC server did not stop")
+	}
+}
+
+func TestInvalidTLSConfigurationIsReportedByStart(t *testing.T) {
+	srv := New(
+		"tls",
+		WithCert("missing.crt"),
+		WithKey("missing.key"),
+		WithPrometheusRegisterer(prometheus.NewRegistry()),
+	)
+	err := srv.Start(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "load gRPC TLS credentials") {
+		t.Fatalf("expected TLS credential error, got %v", err)
+	}
+}
+
+func TestIncompleteTLSConfigurationIsRejected(t *testing.T) {
+	srv := New(
+		"tls",
+		WithCert("server.crt"),
+		WithPrometheusRegisterer(prometheus.NewRegistry()),
+	)
+	if err := srv.Start(context.Background()); !errors.Is(err, ErrIncompleteTLSConfiguration) {
+		t.Fatalf("expected ErrIncompleteTLSConfiguration, got %v", err)
+	}
+}
+
+func TestStartCanOnlyRunOnce(t *testing.T) {
+	started := make(chan struct{})
+	srv := New(
+		"test",
+		WithAddr("127.0.0.1:0"),
+		WithReflection(false),
+		WithPrometheusRegisterer(prometheus.NewRegistry()),
+		WithStartedHook(func() { close(started) }),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Start(ctx)
+	}()
+	<-started
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+	if err := srv.Start(context.Background()); !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("expected ErrAlreadyStarted, got %v", err)
+	}
+}

--- a/mss-boot/core/server/listener/options.go
+++ b/mss-boot/core/server/listener/options.go
@@ -1,26 +1,25 @@
 package listener
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/8 2:15 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/8 2:15 下午
- */
-
 import (
 	"net/http"
 	"time"
 )
 
-// Option 参数设置类型
+// Option configures an HTTP listener.
 type Option func(*Options)
 
+// Options controls the HTTP server and its lifecycle.
 type Options struct {
 	name, addr, certFile, keyFile string
 	handler                       http.Handler
 	startedHook                   func()
 	endHook                       func()
 	timeout                       time.Duration
+	readHeaderTimeout             time.Duration
+	readTimeout                   time.Duration
+	writeTimeout                  time.Duration
+	idleTimeout                   time.Duration
+	shutdownTimeout               time.Duration
 	metrics                       bool
 	healthz                       bool
 	readyz                        bool
@@ -29,93 +28,142 @@ type Options struct {
 
 func defaultOptions() *Options {
 	return &Options{
-		name:    "http",
-		addr:    ":5000",
-		timeout: 10 * time.Second,
-		handler: http.DefaultServeMux,
+		name:              "http",
+		addr:              ":5000",
+		timeout:           10 * time.Second,
+		readHeaderTimeout: 10 * time.Second,
+		readTimeout:       30 * time.Second,
+		writeTimeout:      30 * time.Second,
+		idleTimeout:       2 * time.Minute,
+		shutdownTimeout:   10 * time.Second,
+		handler:           http.DefaultServeMux,
 	}
 }
 
-// WithName set name
+// WithName sets the listener name.
 func WithName(name string) Option {
 	return func(o *Options) {
 		o.name = name
 	}
 }
 
-// WithMetrics set metrics
+// WithMetrics enables the Prometheus metrics route.
 func WithMetrics(enable bool) Option {
 	return func(o *Options) {
 		o.metrics = enable
 	}
 }
 
-// WithHealthz set healthz
+// WithHealthz enables the liveness route.
 func WithHealthz(enable bool) Option {
 	return func(o *Options) {
 		o.healthz = enable
 	}
 }
 
-// WithReadyz set readyz
+// WithReadyz enables the readiness route.
 func WithReadyz(enable bool) Option {
 	return func(o *Options) {
 		o.readyz = enable
 	}
 }
 
-// WithPprof set pprof
+// WithPprof enables pprof routes.
 func WithPprof(enable bool) Option {
 	return func(o *Options) {
 		o.pprof = enable
 	}
 }
 
-// WithEndHook set EndHook
+// WithEndHook registers a function invoked by http.Server during shutdown.
 func WithEndHook(f func()) Option {
 	return func(o *Options) {
 		o.endHook = f
 	}
 }
 
-// WithStartedHook 设置启动回调函数
+// WithStartedHook registers a function invoked after the listening socket is
+// ready and the serve loop has started.
 func WithStartedHook(f func()) Option {
 	return func(o *Options) {
 		o.startedHook = f
 	}
 }
 
-// WithAddr 设置addr
+// WithAddr sets the listen address.
 func WithAddr(s string) Option {
 	return func(o *Options) {
 		o.addr = s
 	}
 }
 
-// WithHandler 设置handler
+// WithHandler sets the HTTP handler.
 func WithHandler(handler http.Handler) Option {
 	return func(o *Options) {
 		o.handler = handler
 	}
 }
 
-// WithCert 设置cert
+// WithCert sets the TLS certificate path.
 func WithCert(s string) Option {
 	return func(o *Options) {
 		o.certFile = s
 	}
 }
 
-// WithKey 设置key
+// WithKey sets the TLS private-key path.
 func WithKey(s string) Option {
 	return func(o *Options) {
 		o.keyFile = s
 	}
 }
 
-// WithTimeout 设置timeout
-func WithTimeout(t int) Option {
+// WithTimeout preserves the legacy seconds-based timeout option while applying
+// it to all HTTP I/O and graceful-shutdown timeouts.
+func WithTimeout(seconds int) Option {
 	return func(o *Options) {
-		o.timeout = time.Second * time.Duration(t)
+		timeout := time.Second * time.Duration(seconds)
+		o.timeout = timeout
+		o.readHeaderTimeout = timeout
+		o.readTimeout = timeout
+		o.writeTimeout = timeout
+		o.idleTimeout = timeout
+		o.shutdownTimeout = timeout
+	}
+}
+
+// WithReadHeaderTimeout limits the time used to read request headers.
+func WithReadHeaderTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.readHeaderTimeout = timeout
+	}
+}
+
+// WithReadTimeout limits the time used to read an entire request.
+func WithReadTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.readTimeout = timeout
+	}
+}
+
+// WithWriteTimeout limits the time used to write a response.
+func WithWriteTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.writeTimeout = timeout
+	}
+}
+
+// WithIdleTimeout limits how long keep-alive connections remain idle.
+func WithIdleTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.idleTimeout = timeout
+	}
+}
+
+// WithShutdownTimeout limits graceful shutdown before active connections are
+// forcefully closed. A non-positive duration waits without a timeout.
+func WithShutdownTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		o.shutdownTimeout = timeout
 	}
 }

--- a/mss-boot/core/server/listener/server.go
+++ b/mss-boot/core/server/listener/server.go
@@ -87,9 +87,6 @@ func (e *Server) Start(ctx context.Context) error {
 			return ctx
 		},
 	}
-	if e.options.endHook != nil {
-		e.srv.RegisterOnShutdown(e.options.endHook)
-	}
 	e.started = true
 	srv := e.srv
 	e.mux.Unlock()
@@ -105,6 +102,9 @@ func (e *Server) Start(ctx context.Context) error {
 
 	if e.options.startedHook != nil {
 		e.options.startedHook()
+	}
+	if e.options.endHook != nil {
+		defer e.options.endHook()
 	}
 	server.PrintRunningInfo(listener.Addr().String(), "http")
 

--- a/mss-boot/core/server/listener/server.go
+++ b/mss-boot/core/server/listener/server.go
@@ -1,18 +1,13 @@
 package listener
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/8 2:04 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/8 2:04 下午
- */
-
 import (
 	"context"
-	"log/slog"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"sync"
 
 	ginPprof "github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
@@ -20,118 +15,182 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// Server server manage
+var (
+	// ErrAlreadyStarted is returned when an HTTP listener is started twice.
+	ErrAlreadyStarted = errors.New("HTTP server has already been started")
+	// ErrIncompleteTLSConfiguration is returned when only one TLS file is set.
+	ErrIncompleteTLSConfiguration = errors.New("both TLS certificate and key files are required")
+)
+
+// Server is a managed HTTP listener.
 type Server struct {
-	ctx     context.Context
+	mux     sync.Mutex
 	srv     *http.Server
 	options Options
 	started bool
 }
 
-// New 实例化
+// New creates an HTTP listener. It returns nil when no handler is configured,
+// preserving the historical optional-listener behavior.
 func New(opts ...Option) server.Runnable {
 	s := &Server{}
-
 	s.Options(opts...)
 	if s.options.handler == nil {
 		return nil
 	}
-	switch h := s.options.handler.(type) {
-	case *http.ServeMux:
-		if s.options.pprof && h != http.DefaultServeMux {
-			h.HandleFunc("/debug/pprof/", pprof.Index)
-			h.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-			h.HandleFunc("/debug/pprof/profile", pprof.Profile)
-			h.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-			h.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		}
-		if s.options.metrics {
-			h.Handle("/metrics", promhttp.Handler())
-		}
-		if s.options.healthz {
-			h.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			})
-		}
-		if s.options.readyz {
-			h.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			})
-		}
-		s.options.handler = h
-	case *gin.Engine:
-		if s.options.pprof {
-			ginPprof.Register(h)
-		}
-		if s.options.metrics {
-			h.GET("/metrics", gin.WrapH(promhttp.Handler()))
-		}
-		if s.options.healthz {
-			h.GET("/healthz", func(c *gin.Context) {
-				c.AbortWithStatus(http.StatusOK)
-			})
-		}
-		if s.options.readyz {
-			h.GET("/readyz", func(c *gin.Context) {
-				c.AbortWithStatus(http.StatusOK)
-			})
-		}
-	}
+	s.registerOperationalRoutes()
 	return s
 }
 
-// Options 设置参数
+// Options resets the listener to defaults and applies options.
 func (e *Server) Options(options ...Option) {
 	e.options = *defaultOptions()
-	for _, o := range options {
-		o(&e.options)
+	for _, option := range options {
+		if option != nil {
+			option(&e.options)
+		}
 	}
 }
 
-// String string
+// String returns the listener name.
 func (e *Server) String() string {
 	return e.options.name
 }
 
-// Start server
+// Start listens and blocks until the HTTP server exits or ctx is cancelled.
 func (e *Server) Start(ctx context.Context) error {
-	l, err := net.Listen("tcp", e.options.addr)
-	if err != nil {
-		return err
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	e.ctx = ctx
-	e.started = true
-	e.srv = &http.Server{Handler: e.options.handler}
+	if (e.options.certFile == "") != (e.options.keyFile == "") {
+		return ErrIncompleteTLSConfiguration
+	}
+
+	e.mux.Lock()
+	if e.started {
+		e.mux.Unlock()
+		return ErrAlreadyStarted
+	}
+	listener, err := net.Listen("tcp", e.options.addr)
+	if err != nil {
+		e.mux.Unlock()
+		return fmt.Errorf("HTTP server listening on %s failed: %w", e.options.addr, err)
+	}
+
+	e.srv = &http.Server{
+		Handler:           e.options.handler,
+		ReadHeaderTimeout: e.options.readHeaderTimeout,
+		ReadTimeout:       e.options.readTimeout,
+		WriteTimeout:      e.options.writeTimeout,
+		IdleTimeout:       e.options.idleTimeout,
+		BaseContext: func(net.Listener) context.Context {
+			return ctx
+		},
+	}
 	if e.options.endHook != nil {
 		e.srv.RegisterOnShutdown(e.options.endHook)
 	}
-	e.srv.BaseContext = func(_ net.Listener) context.Context {
-		return ctx
-	}
+	e.started = true
+	srv := e.srv
+	e.mux.Unlock()
+
+	serveErr := make(chan error, 1)
 	go func() {
-		if e.options.keyFile == "" || e.options.certFile == "" {
-			if err = e.srv.Serve(l); err != nil {
-				slog.ErrorContext(ctx, e.options.name+" Server start error", slog.Any("err", err.Error()))
-			}
-		} else {
-			if err = e.srv.ServeTLS(l, e.options.certFile, e.options.keyFile); err != nil {
-				slog.ErrorContext(ctx, e.options.name+" Server start error", slog.Any("err", err.Error()))
-			}
+		if e.options.certFile == "" {
+			serveErr <- srv.Serve(listener)
+			return
 		}
-		<-ctx.Done()
-		err = e.Shutdown(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, e.options.name+" Server shutdown error", slog.Any("err", err.Error()))
-		}
+		serveErr <- srv.ServeTLS(listener, e.options.certFile, e.options.keyFile)
 	}()
+
 	if e.options.startedHook != nil {
 		e.options.startedHook()
 	}
-	server.PrintRunningInfo(e.options.addr, "http")
-	return nil
+	server.PrintRunningInfo(listener.Addr().String(), "http")
+
+	select {
+	case err := <-serveErr:
+		return normalizeServeError(err)
+	case <-ctx.Done():
+		shutdownErr := e.shutdownWithTimeout()
+		if shutdownErr != nil {
+			closeErr := srv.Close()
+			shutdownErr = errors.Join(shutdownErr, normalizeServeError(closeErr))
+		}
+		return errors.Join(shutdownErr, normalizeServeError(<-serveErr))
+	}
 }
 
-// Shutdown 停止
+// Shutdown gracefully stops the HTTP server.
 func (e *Server) Shutdown(ctx context.Context) error {
-	return e.srv.Shutdown(ctx)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.mux.Lock()
+	srv := e.srv
+	e.mux.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
+}
+
+func (e *Server) shutdownWithTimeout() error {
+	if e.options.shutdownTimeout <= 0 {
+		return e.Shutdown(context.Background())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), e.options.shutdownTimeout)
+	defer cancel()
+	return e.Shutdown(ctx)
+}
+
+func normalizeServeError(err error) error {
+	if err == nil || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (e *Server) registerOperationalRoutes() {
+	switch handler := e.options.handler.(type) {
+	case *http.ServeMux:
+		if e.options.pprof && handler != http.DefaultServeMux {
+			handler.HandleFunc("/debug/pprof/", pprof.Index)
+			handler.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			handler.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			handler.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			handler.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		}
+		if e.options.metrics {
+			handler.Handle("/metrics", promhttp.Handler())
+		}
+		if e.options.healthz {
+			handler.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		}
+		if e.options.readyz {
+			handler.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+		}
+		e.options.handler = handler
+	case *gin.Engine:
+		if e.options.pprof {
+			ginPprof.Register(handler)
+		}
+		if e.options.metrics {
+			handler.GET("/metrics", gin.WrapH(promhttp.Handler()))
+		}
+		if e.options.healthz {
+			handler.GET("/healthz", func(c *gin.Context) {
+				c.AbortWithStatus(http.StatusOK)
+			})
+		}
+		if e.options.readyz {
+			handler.GET("/readyz", func(c *gin.Context) {
+				c.AbortWithStatus(http.StatusOK)
+			})
+		}
+	}
 }

--- a/mss-boot/core/server/listener/server_test.go
+++ b/mss-boot/core/server/listener/server_test.go
@@ -1,0 +1,121 @@
+package listener
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestStartBlocksUntilCancellationAndRunsHooks(t *testing.T) {
+	started := make(chan struct{})
+	ended := make(chan struct{})
+	runnable := New(
+		WithAddr("127.0.0.1:0"),
+		WithHandler(http.NewServeMux()),
+		WithStartedHook(func() { close(started) }),
+		WithEndHook(func() { close(ended) }),
+		WithShutdownTimeout(time.Second),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runnable.Start(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("HTTP listener did not start")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned before cancellation: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("graceful shutdown failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP listener did not stop")
+	}
+	select {
+	case <-ended:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown hook was not invoked")
+	}
+}
+
+func TestStartReturnsListenError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve address: %v", err)
+	}
+	defer listener.Close()
+
+	runnable := New(
+		WithAddr(listener.Addr().String()),
+		WithHandler(http.NewServeMux()),
+	)
+	if err := runnable.Start(context.Background()); err == nil {
+		t.Fatal("expected a listen error")
+	}
+}
+
+func TestStartRejectsIncompleteTLSConfiguration(t *testing.T) {
+	runnable := New(
+		WithAddr("127.0.0.1:0"),
+		WithHandler(http.NewServeMux()),
+		WithCert("server.crt"),
+	)
+	if err := runnable.Start(context.Background()); !errors.Is(err, ErrIncompleteTLSConfiguration) {
+		t.Fatalf("expected ErrIncompleteTLSConfiguration, got %v", err)
+	}
+}
+
+func TestWithTimeoutConfiguresHTTPAndShutdownTimeouts(t *testing.T) {
+	options := defaultOptions()
+	WithTimeout(7)(options)
+	want := 7 * time.Second
+	for name, got := range map[string]time.Duration{
+		"legacy":     options.timeout,
+		"readHeader": options.readHeaderTimeout,
+		"read":       options.readTimeout,
+		"write":      options.writeTimeout,
+		"idle":       options.idleTimeout,
+		"shutdown":   options.shutdownTimeout,
+	} {
+		if got != want {
+			t.Fatalf("%s timeout = %s, want %s", name, got, want)
+		}
+	}
+}
+
+func TestStartCanOnlyRunOnce(t *testing.T) {
+	started := make(chan struct{})
+	runnable := New(
+		WithAddr("127.0.0.1:0"),
+		WithHandler(http.NewServeMux()),
+		WithStartedHook(func() { close(started) }),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- runnable.Start(ctx)
+	}()
+	<-started
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+	if err := runnable.Start(context.Background()); !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("expected ErrAlreadyStarted, got %v", err)
+	}
+}

--- a/mss-boot/core/server/manager.go
+++ b/mss-boot/core/server/manager.go
@@ -1,26 +1,22 @@
 package server
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/7 5:39 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/7 5:39 下午
- */
-
 import (
 	"context"
 	"fmt"
 )
 
-// Manager server manage
+// Manager coordinates the lifecycle of one or more Runnable components.
 type Manager interface {
 	Add(...Runnable)
 	Start(context.Context) error
 }
 
-// Runnable runnable
+// Runnable is a long-running component managed by Manager.
+//
+// Start must block until the component stops, the supplied context is
+// cancelled, or an unrecoverable runtime error occurs. Implementations must
+// release owned resources before returning.
 type Runnable interface {
 	fmt.Stringer
-	// Start 启动
 	Start(ctx context.Context) error
 }

--- a/mss-boot/core/server/options.go
+++ b/mss-boot/core/server/options.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const defaultGracefulShutdownTimeout = 30 * time.Second
+
 // Option configures a Server manager.
 type Option func(*Options)
 
@@ -17,14 +19,18 @@ type Options struct {
 
 func setDefaultOptions() Options {
 	return Options{
-		gracefulShutdownTimeout: 5 * time.Second,
+		// The manager is the outer lifecycle deadline. Keep its default longer
+		// than the built-in HTTP, gRPC, and task shutdown deadlines so adapters
+		// can report their own timeout errors before the manager gives up.
+		gracefulShutdownTimeout: defaultGracefulShutdownTimeout,
 		signals:                 []os.Signal{os.Interrupt, syscall.SIGTERM},
 	}
 }
 
 // WithGracefulShutdownTimeout sets the maximum time the manager waits for all
 // runnables to return after cancellation. A non-positive duration waits without
-// a timeout.
+// a timeout. This outer deadline should exceed each component's own shutdown
+// timeout so component-specific errors can be collected.
 func WithGracefulShutdownTimeout(timeout time.Duration) Option {
 	return func(options *Options) {
 		options.gracefulShutdownTimeout = timeout

--- a/mss-boot/core/server/options.go
+++ b/mss-boot/core/server/options.go
@@ -1,24 +1,46 @@
 package server
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/7 5:54 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/7 5:54 下午
- */
+import (
+	"os"
+	"syscall"
+	"time"
+)
 
-import "time"
-
-// Option set Options
+// Option configures a Server manager.
 type Option func(*Options)
 
-// Options options
+// Options controls process-signal handling and graceful shutdown.
 type Options struct {
 	gracefulShutdownTimeout time.Duration
+	signals                 []os.Signal
 }
 
 func setDefaultOptions() Options {
 	return Options{
 		gracefulShutdownTimeout: 5 * time.Second,
+		signals:                 []os.Signal{os.Interrupt, syscall.SIGTERM},
 	}
+}
+
+// WithGracefulShutdownTimeout sets the maximum time the manager waits for all
+// runnables to return after cancellation. A non-positive duration waits without
+// a timeout.
+func WithGracefulShutdownTimeout(timeout time.Duration) Option {
+	return func(options *Options) {
+		options.gracefulShutdownTimeout = timeout
+	}
+}
+
+// WithSignals replaces the operating-system signals handled by the manager.
+// Passing no signals disables signal handling.
+func WithSignals(signals ...os.Signal) Option {
+	return func(options *Options) {
+		options.signals = append([]os.Signal(nil), signals...)
+	}
+}
+
+// WithoutSignalHandling leaves operating-system signal ownership to the
+// embedding application. Context cancellation still stops all runnables.
+func WithoutSignalHandling() Option {
+	return WithSignals()
 }

--- a/mss-boot/core/server/options_test.go
+++ b/mss-boot/core/server/options_test.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultGracefulShutdownTimeoutIsOuterDeadline(t *testing.T) {
+	options := setDefaultOptions()
+	if options.gracefulShutdownTimeout != 30*time.Second {
+		t.Fatalf(
+			"default graceful shutdown timeout = %s, want 30s",
+			options.gracefulShutdownTimeout,
+		)
+	}
+}

--- a/mss-boot/core/server/server.go
+++ b/mss-boot/core/server/server.go
@@ -118,6 +118,11 @@ func (e *Server) Start(ctx context.Context) error {
 	case <-runCtx.Done():
 		// Caller cancellation and process signals are normal shutdown paths.
 	case result := <-results:
+		if runCtx.Err() != nil {
+			// A runnable may observe cancellation and return at the same instant as
+			// this select. External cancellation remains a normal shutdown path.
+			break
+		}
 		if result.err != nil {
 			runErr = fmt.Errorf("runnable %q failed: %w", result.name, result.err)
 		} else {

--- a/mss-boot/core/server/server.go
+++ b/mss-boot/core/server/server.go
@@ -1,177 +1,173 @@
 package server
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/7 5:43 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/7 5:43 下午
- */
-
 import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"sync"
-	"syscall"
+	"time"
 )
 
-// Server server
+var (
+	// ErrAlreadyStarted is returned when a manager is started more than once.
+	ErrAlreadyStarted = errors.New("server manager has already been started")
+	// ErrRunnableStopped is returned when a runnable exits successfully before
+	// the manager has begun its shutdown sequence.
+	ErrRunnableStopped = errors.New("runnable stopped before shutdown")
+	// ErrGracefulShutdownTimeout is returned when one or more runnables fail to
+	// stop within the configured grace period.
+	ErrGracefulShutdownTimeout = errors.New("graceful shutdown timed out")
+)
+
+// Server coordinates Runnable components as one lifecycle unit.
 type Server struct {
-	services               map[string]Runnable
-	started                sync.Map
-	mux                    sync.Mutex
-	errChan                chan error
-	waitForRunnable        sync.WaitGroup
-	internalCtx            context.Context
-	internalCancel         context.CancelFunc
-	internalProceduresStop chan struct{}
-	shutdownCtx            context.Context
-	shutdownCancel         context.CancelFunc
-	opts                   Options
+	mux      sync.Mutex
+	services map[string]Runnable
+	order    []string
+	started  bool
+	opts     Options
 }
 
-// New 实例化
+// New creates a server manager.
 func New(opts ...Option) Manager {
 	s := &Server{
-		services:               make(map[string]Runnable),
-		errChan:                make(chan error),
-		internalProceduresStop: make(chan struct{}),
+		services: make(map[string]Runnable),
+		opts:     setDefaultOptions(),
 	}
-	s.opts = setDefaultOptions()
-	for i := range opts {
-		opts[i](&s.opts)
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&s.opts)
+		}
 	}
 	return s
 }
 
-// Add runnable
-func (e *Server) Add(r ...Runnable) {
+// Add registers runnables before Start is called. A runnable with the same name
+// replaces the previous registration while preserving deterministic start
+// order. Nil runnables and additions after Start are ignored for compatibility
+// with the existing interface, which cannot return an error.
+func (e *Server) Add(runnables ...Runnable) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+
+	if e.started {
+		return
+	}
 	if e.services == nil {
 		e.services = make(map[string]Runnable)
 	}
-	for i := range r {
-		if r[i] == nil {
+	for _, runnable := range runnables {
+		if runnable == nil {
 			continue
 		}
-		e.services[r[i].String()] = r[i]
+		name := runnable.String()
+		if _, exists := e.services[name]; !exists {
+			e.order = append(e.order, name)
+		}
+		e.services[name] = runnable
 	}
 }
 
-// Start runnable
-func (e *Server) Start(ctx context.Context) (err error) {
-	//e.mux.Lock()
-	//defer e.mux.Unlock()
-	e.internalCtx, e.internalCancel = context.WithCancel(ctx)
-	stopComplete := make(chan struct{})
-	defer close(stopComplete)
-	defer func() {
-		stopErr := e.engageStopProcedure(stopComplete)
-		if stopErr != nil {
-			if err != nil {
-				err = fmt.Errorf("%s, %w", stopErr.Error(), err)
-			} else {
-				err = stopErr
-			}
-		}
-	}()
-	e.errChan = make(chan error, len(e.services))
+// Start runs all registered components concurrently. The first unexpected
+// component exit or runtime error cancels every peer. Cancellation from the
+// caller or a configured operating-system signal is treated as a normal stop.
+func (e *Server) Start(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	for k := range e.services {
-		if e.getStarted(k) {
-			//先判断是否可以启动
-			return errors.New("can't accept new runnable as stop procedure is already engaged")
-		}
-	}
-	//按顺序启动
-	for k := range e.services {
-		e.startRunnable(e.services[k])
-		e.setStarted(k)
-	}
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	e.waitForRunnable.Wait()
-	select {
-	case <-ctx.Done():
-		return nil
-	case err = <-e.errChan:
+	runnables, options, err := e.beginStart()
+	if err != nil {
 		return err
-	case <-done:
-		// 优雅退出
-		fmt.Println("received SIGINT, shutting down server")
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if len(options.signals) > 0 {
+		var stopSignals context.CancelFunc
+		runCtx, stopSignals = signal.NotifyContext(runCtx, options.signals...)
+		defer stopSignals()
+	}
+
+	if len(runnables) == 0 {
+		<-runCtx.Done()
 		return nil
 	}
+
+	type result struct {
+		name string
+		err  error
+	}
+
+	results := make(chan result, len(runnables))
+	var wait sync.WaitGroup
+	wait.Add(len(runnables))
+	for _, runnable := range runnables {
+		runnable := runnable
+		go func() {
+			defer wait.Done()
+			results <- result{name: runnable.String(), err: runnable.Start(runCtx)}
+		}()
+	}
+
+	var runErr error
+	select {
+	case <-runCtx.Done():
+		// Caller cancellation and process signals are normal shutdown paths.
+	case result := <-results:
+		if result.err != nil {
+			runErr = fmt.Errorf("runnable %q failed: %w", result.name, result.err)
+		} else {
+			runErr = fmt.Errorf("runnable %q: %w", result.name, ErrRunnableStopped)
+		}
+	}
+
+	cancel()
+	shutdownErr := waitForRunnables(&wait, options.gracefulShutdownTimeout)
+	return errors.Join(runErr, shutdownErr)
 }
 
-func (e *Server) startRunnable(r Runnable) {
-	e.waitForRunnable.Add(1)
-	go func() {
-		defer e.waitForRunnable.Done()
-		if err := r.Start(e.internalCtx); err != nil {
-			e.errChan <- err
-		}
-	}()
-}
-
-func (e *Server) engageStopProcedure(stopComplete <-chan struct{}) error {
-	if e.opts.gracefulShutdownTimeout > 0 {
-		e.shutdownCtx, e.shutdownCancel = context.WithTimeout(
-			context.Background(), e.opts.gracefulShutdownTimeout)
-	} else {
-		e.shutdownCtx, e.shutdownCancel = context.WithCancel(context.Background())
-	}
-	defer e.shutdownCancel()
-	close(e.internalProceduresStop)
-	e.internalCancel()
-
-	go func() {
-		for {
-			select {
-			case err, ok := <-e.errChan:
-				if ok {
-					slog.Error("error received after stop sequence was engaged", slog.Any("err", err))
-				}
-			case <-stopComplete:
-				return
-			}
-		}
-	}()
-	if e.opts.gracefulShutdownTimeout == 0 {
-		return nil
-	}
+func (e *Server) beginStart() ([]Runnable, Options, error) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
-	return e.waitForRunnableToEnd(e.shutdownCancel)
-}
 
-func (e *Server) waitForRunnableToEnd(shutdownCancel context.CancelFunc) error {
-	go func() {
-		e.waitForRunnable.Wait()
-		shutdownCancel()
-	}()
-	<-e.shutdownCtx.Done()
-	if err := e.shutdownCtx.Err(); err != nil && err != context.Canceled {
-		return fmt.Errorf(
-			"failed waiting for all runnables to end within grace period of %s: %w",
-			e.opts.gracefulShutdownTimeout, err)
+	if e.started {
+		return nil, Options{}, ErrAlreadyStarted
 	}
-	return nil
-}
+	e.started = true
 
-func (e *Server) setStarted(key string) {
-	e.started.Store(key, true)
-}
-
-func (e *Server) getStarted(keys ...string) bool {
-	var start bool
-	for i := range keys {
-		v, ok := e.started.Load(keys[i])
-		start = start || (ok && v.(bool))
-		if start {
-			return start
+	runnables := make([]Runnable, 0, len(e.order))
+	for _, name := range e.order {
+		if runnable := e.services[name]; runnable != nil {
+			runnables = append(runnables, runnable)
 		}
 	}
-	return start
+	options := e.opts
+	options.signals = append([]os.Signal(nil), e.opts.signals...)
+	return runnables, options, nil
+}
+
+func waitForRunnables(wait *sync.WaitGroup, timeout time.Duration) error {
+	done := make(chan struct{})
+	go func() {
+		wait.Wait()
+		close(done)
+	}()
+
+	if timeout <= 0 {
+		<-done
+		return nil
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("%w after %s", ErrGracefulShutdownTimeout, timeout)
+	}
 }

--- a/mss-boot/core/server/server.go
+++ b/mss-boot/core/server/server.go
@@ -21,6 +21,11 @@ var (
 	ErrGracefulShutdownTimeout = errors.New("graceful shutdown timed out")
 )
 
+type runnableResult struct {
+	name string
+	err  error
+}
+
 // Server coordinates Runnable components as one lifecycle unit.
 type Server struct {
 	mux      sync.Mutex
@@ -97,41 +102,37 @@ func (e *Server) Start(ctx context.Context) error {
 		return nil
 	}
 
-	type result struct {
-		name string
-		err  error
-	}
-
-	results := make(chan result, len(runnables))
+	results := make(chan runnableResult, len(runnables))
 	var wait sync.WaitGroup
 	wait.Add(len(runnables))
 	for _, runnable := range runnables {
 		runnable := runnable
 		go func() {
 			defer wait.Done()
-			results <- result{name: runnable.String(), err: runnable.Start(runCtx)}
+			results <- runnableResult{name: runnable.String(), err: runnable.Start(runCtx)}
 		}()
 	}
 
 	var runErr error
+	received := 0
 	select {
 	case <-runCtx.Done():
 		// Caller cancellation and process signals are normal shutdown paths.
 	case result := <-results:
+		received++
 		if runCtx.Err() != nil {
-			// A runnable may observe cancellation and return at the same instant as
-			// this select. External cancellation remains a normal shutdown path.
-			break
-		}
-		if result.err != nil {
-			runErr = fmt.Errorf("runnable %q failed: %w", result.name, result.err)
+			// A runnable may observe external cancellation and return at the same
+			// instant as this select. Preserve real shutdown errors while treating
+			// the matching context error as normal.
+			runErr = errors.Join(runErr, shutdownResultError(result.name, result.err, runCtx.Err()))
 		} else {
-			runErr = fmt.Errorf("runnable %q: %w", result.name, ErrRunnableStopped)
+			runErr = errors.Join(runErr, runningResultError(result.name, result.err))
 		}
 	}
 
 	cancel()
 	shutdownErr := waitForRunnables(&wait, options.gracefulShutdownTimeout)
+	runErr = errors.Join(runErr, collectShutdownResults(results, len(runnables), received, runCtx.Err(), shutdownErr == nil))
 	return errors.Join(runErr, shutdownErr)
 }
 
@@ -153,6 +154,52 @@ func (e *Server) beginStart() ([]Runnable, Options, error) {
 	options := e.opts
 	options.signals = append([]os.Signal(nil), e.opts.signals...)
 	return runnables, options, nil
+}
+
+func runningResultError(name string, err error) error {
+	if err != nil {
+		return fmt.Errorf("runnable %q failed: %w", name, err)
+	}
+	return fmt.Errorf("runnable %q: %w", name, ErrRunnableStopped)
+}
+
+func shutdownResultError(name string, err, cancellationErr error) error {
+	if err == nil {
+		return nil
+	}
+	if err == context.Canceled || (cancellationErr != nil && err == cancellationErr) {
+		return nil
+	}
+	return fmt.Errorf("runnable %q failed during shutdown: %w", name, err)
+}
+
+func collectShutdownResults(
+	results <-chan runnableResult,
+	total int,
+	received int,
+	cancellationErr error,
+	waitCompleted bool,
+) error {
+	var resultErr error
+	if waitCompleted {
+		for received < total {
+			result := <-results
+			received++
+			resultErr = errors.Join(resultErr, shutdownResultError(result.name, result.err, cancellationErr))
+		}
+		return resultErr
+	}
+
+	for received < total {
+		select {
+		case result := <-results:
+			received++
+			resultErr = errors.Join(resultErr, shutdownResultError(result.name, result.err, cancellationErr))
+		default:
+			return resultErr
+		}
+	}
+	return resultErr
 }
 
 func waitForRunnables(wait *sync.WaitGroup, timeout time.Duration) error {

--- a/mss-boot/core/server/server.go
+++ b/mss-boot/core/server/server.go
@@ -167,7 +167,7 @@ func shutdownResultError(name string, err, cancellationErr error) error {
 	if err == nil {
 		return nil
 	}
-	if err == context.Canceled || (cancellationErr != nil && err == cancellationErr) {
+	if errors.Is(err, context.Canceled) || (cancellationErr != nil && errors.Is(err, cancellationErr)) {
 		return nil
 	}
 	return fmt.Errorf("runnable %q failed during shutdown: %w", name, err)

--- a/mss-boot/core/server/server_test.go
+++ b/mss-boot/core/server/server_test.go
@@ -134,6 +134,24 @@ func TestServerReturnsShutdownTimeout(t *testing.T) {
 	}
 }
 
+func TestServerTreatsPreCancelledContextAsCleanShutdown(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		manager := New(WithoutSignalHandling())
+		manager.Add(&testRunnable{
+			name: "service",
+			start: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := manager.Start(ctx); err != nil {
+			t.Fatalf("iteration %d: expected clean shutdown, got %v", i, err)
+		}
+	}
+}
+
 func TestServerCanOnlyStartOnce(t *testing.T) {
 	manager := New(WithoutSignalHandling())
 	started := make(chan struct{})

--- a/mss-boot/core/server/server_test.go
+++ b/mss-boot/core/server/server_test.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testRunnable struct {
+	name  string
+	start func(context.Context) error
+}
+
+func (r *testRunnable) String() string {
+	return r.name
+}
+
+func (r *testRunnable) Start(ctx context.Context) error {
+	return r.start(ctx)
+}
+
+func TestServerStopsRunnablesOnContextCancellation(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+
+	started := make(chan string, 2)
+	stopped := make(chan string, 2)
+	for _, name := range []string{"http", "worker"} {
+		name := name
+		manager.Add(&testRunnable{
+			name: name,
+			start: func(ctx context.Context) error {
+				started <- name
+				<-ctx.Done()
+				stopped <- name
+				return nil
+			},
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+
+	waitForNames(t, started, 2)
+	cancel()
+
+	if err := receiveError(t, done); err != nil {
+		t.Fatalf("expected a clean shutdown, got %v", err)
+	}
+	waitForNames(t, stopped, 2)
+}
+
+func TestServerPropagatesRuntimeErrorAndCancelsPeers(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	sentinel := errors.New("serve failed")
+	peerStarted := make(chan struct{})
+	peerStopped := make(chan struct{})
+
+	manager.Add(
+		&testRunnable{
+			name: "peer",
+			start: func(ctx context.Context) error {
+				close(peerStarted)
+				<-ctx.Done()
+				close(peerStopped)
+				return nil
+			},
+		},
+		&testRunnable{
+			name: "failing",
+			start: func(context.Context) error {
+				<-peerStarted
+				return sentinel
+			},
+		},
+	)
+
+	err := manager.Start(context.Background())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected runtime error %v, got %v", sentinel, err)
+	}
+	select {
+	case <-peerStopped:
+	case <-time.After(time.Second):
+		t.Fatal("peer runnable was not cancelled")
+	}
+}
+
+func TestServerRejectsUnexpectedSuccessfulExit(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	manager.Add(&testRunnable{
+		name:  "short-lived",
+		start: func(context.Context) error { return nil },
+	})
+
+	err := manager.Start(context.Background())
+	if !errors.Is(err, ErrRunnableStopped) {
+		t.Fatalf("expected ErrRunnableStopped, got %v", err)
+	}
+}
+
+func TestServerReturnsShutdownTimeout(t *testing.T) {
+	manager := New(
+		WithoutSignalHandling(),
+		WithGracefulShutdownTimeout(20*time.Millisecond),
+	)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	manager.Add(&testRunnable{
+		name: "stuck",
+		start: func(context.Context) error {
+			close(started)
+			<-release
+			return nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	<-started
+	cancel()
+
+	err := receiveError(t, done)
+	close(release)
+	if !errors.Is(err, ErrGracefulShutdownTimeout) {
+		t.Fatalf("expected ErrGracefulShutdownTimeout, got %v", err)
+	}
+}
+
+func TestServerCanOnlyStartOnce(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	started := make(chan struct{})
+	manager.Add(&testRunnable{
+		name: "service",
+		start: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	<-started
+	cancel()
+	if err := receiveError(t, done); err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+
+	if err := manager.Start(context.Background()); !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("expected ErrAlreadyStarted, got %v", err)
+	}
+}
+
+func TestServerPreservesRegistrationOrderWhenReplacingRunnable(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	serverManager := manager.(*Server)
+
+	manager.Add(
+		&testRunnable{name: "first", start: waitForCancellation},
+		&testRunnable{name: "second", start: waitForCancellation},
+	)
+	manager.Add(&testRunnable{name: "first", start: waitForCancellation})
+
+	serverManager.mux.Lock()
+	defer serverManager.mux.Unlock()
+	if len(serverManager.order) != 2 {
+		t.Fatalf("expected two ordered registrations, got %d", len(serverManager.order))
+	}
+	if serverManager.order[0] != "first" || serverManager.order[1] != "second" {
+		t.Fatalf("unexpected registration order: %v", serverManager.order)
+	}
+}
+
+func waitForCancellation(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func receiveError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for manager")
+		return nil
+	}
+}
+
+func waitForNames(t *testing.T, ch <-chan string, count int) {
+	t.Helper()
+	seen := make(map[string]struct{}, count)
+	var mux sync.Mutex
+	for len(seen) < count {
+		select {
+		case name := <-ch:
+			mux.Lock()
+			seen[name] = struct{}{}
+			mux.Unlock()
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for %d names; got %v", count, seen)
+		}
+	}
+}

--- a/mss-boot/core/server/shutdown_test.go
+++ b/mss-boot/core/server/shutdown_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -54,5 +55,30 @@ func TestServerIgnoresMatchingContextErrorDuringShutdown(t *testing.T) {
 
 	if err := receiveError(t, done); err != nil {
 		t.Fatalf("expected matching context error to be ignored, got %v", err)
+	}
+}
+
+func TestServerIgnoresWrappedContextErrorDuringShutdown(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	started := make(chan struct{})
+	manager.Add(&testRunnable{
+		name: "worker",
+		start: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return fmt.Errorf("worker stopped: %w", ctx.Err())
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	<-started
+	cancel()
+
+	if err := receiveError(t, done); err != nil {
+		t.Fatalf("expected wrapped context error to be ignored, got %v", err)
 	}
 }

--- a/mss-boot/core/server/shutdown_test.go
+++ b/mss-boot/core/server/shutdown_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestServerPropagatesRunnableShutdownError(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	started := make(chan struct{})
+	shutdownErr := errors.New("flush failed")
+	manager.Add(&testRunnable{
+		name: "worker",
+		start: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return shutdownErr
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	<-started
+	cancel()
+
+	if err := receiveError(t, done); !errors.Is(err, shutdownErr) {
+		t.Fatalf("expected shutdown error %v, got %v", shutdownErr, err)
+	}
+}
+
+func TestServerIgnoresMatchingContextErrorDuringShutdown(t *testing.T) {
+	manager := New(WithoutSignalHandling())
+	started := make(chan struct{})
+	manager.Add(&testRunnable{
+		name: "worker",
+		start: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(ctx)
+	}()
+	<-started
+	cancel()
+
+	if err := receiveError(t, done); err != nil {
+		t.Fatalf("expected matching context error to be ignored, got %v", err)
+	}
+}

--- a/mss-boot/core/server/task/options.go
+++ b/mss-boot/core/server/task/options.go
@@ -1,17 +1,14 @@
 package task
 
-/*
- * @Author: lwnmengjing<lwnmengjing@qq.com>
- * @Date: 2023/2/21 16:23:53
- * @Last Modified by: lwnmengjing<lwnmengjing@qq.com>
- * @Last Modified time: 2023/2/21 16:23:53
- */
-
 import (
+	"time"
+
 	"github.com/robfig/cron/v3"
 )
 
-// Option params set
+const defaultShutdownTimeout = 5 * time.Second
+
+// Option configures the task server.
 type Option func(*options)
 
 type schedule struct {
@@ -21,30 +18,39 @@ type schedule struct {
 }
 
 type options struct {
-	task    *cron.Cron
-	storage Storage
+	task            *cron.Cron
+	storage         Storage
+	shutdownTimeout time.Duration
 }
 
-// WithSchedule set schedule
+// WithSchedule registers a schedule in task storage.
 func WithSchedule(key string, spec string, job cron.Job) Option {
 	return func(o *options) {
 		_ = o.storage.Set(key, 0, spec, job)
 	}
 }
 
-// WithStorage set storage
-func WithStorage(s Storage) Option {
+// WithStorage replaces task storage.
+func WithStorage(storage Storage) Option {
 	return func(o *options) {
-		o.storage = s
+		if storage != nil {
+			o.storage = storage
+		}
 	}
+}
 
+// WithShutdownTimeout limits how long Start waits for running cron jobs after
+// cancellation. A non-positive duration waits without a timeout.
+func WithShutdownTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.shutdownTimeout = timeout
+	}
 }
 
 func setDefaultOption() options {
 	return options{
-		task: cron.New(cron.WithSeconds(), cron.WithChain()),
-		storage: &defaultStorage{
-			schedules: make(map[string]*schedule),
-		},
+		task:            cron.New(cron.WithSeconds(), cron.WithChain()),
+		storage:         &defaultStorage{schedules: make(map[string]*schedule)},
+		shutdownTimeout: defaultShutdownTimeout,
 	}
 }

--- a/mss-boot/core/server/task/server.go
+++ b/mss-boot/core/server/task/server.go
@@ -98,7 +98,7 @@ func (e *Server) String() string {
 }
 
 // Start loads jobs, starts cron, and blocks until ctx is cancelled and running
-// jobs have completed.
+// jobs have completed or the configured shutdown timeout expires.
 func (e *Server) Start(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -143,7 +143,7 @@ func (e *Server) Start(ctx context.Context) error {
 	e.mux.Unlock()
 
 	<-ctx.Done()
-	return e.Shutdown(context.Background())
+	return e.shutdownWithTimeout()
 }
 
 // Shutdown stops scheduling new work and waits for running jobs to finish.
@@ -166,4 +166,13 @@ func (e *Server) Shutdown(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+func (e *Server) shutdownWithTimeout() error {
+	if e.opts.shutdownTimeout <= 0 {
+		return e.Shutdown(context.Background())
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), e.opts.shutdownTimeout)
+	defer cancel()
+	return e.Shutdown(ctx)
 }

--- a/mss-boot/core/server/task/server.go
+++ b/mss-boot/core/server/task/server.go
@@ -1,36 +1,37 @@
 package task
 
-/*
- * @Author: lwnmengjing<lwnmengjing@qq.com>
- * @Date: 2023/2/21 15:35:43
- * @Last Modified by: lwnmengjing<lwnmengjing@qq.com>
- * @Last Modified time: 2023/2/21 15:35:43
- */
-
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync"
 
 	"github.com/robfig/cron/v3"
 )
 
-var task = &Server{
-	opts: setDefaultOption(),
-}
+var (
+	task = &Server{
+		opts: setDefaultOption(),
+	}
+	// ErrAlreadyStarted is returned when a task server is started twice.
+	ErrAlreadyStarted = errors.New("task server has already been started")
+)
 
-// Server manage
+// Server manages scheduled jobs.
 type Server struct {
-	ctx  context.Context
-	opts options
+	ctx     context.Context
+	opts    options
+	mux     sync.Mutex
+	started bool
 }
 
-// New server
+// New configures and returns the process-wide task server for compatibility.
 func New(opts ...Option) *Server {
 	task.Options(opts...)
 	return task
 }
 
-// GetJob get job
+// GetJob returns a configured job.
 func GetJob(key string) (string, cron.Job, bool) {
 	_, spec, job, ok, _ := task.opts.storage.Get(key)
 	if !ok {
@@ -39,37 +40,35 @@ func GetJob(key string) (string, cron.Job, bool) {
 	return spec, job, true
 }
 
-// Entry get entry
+// Entry returns a cron entry.
 func Entry(entryID cron.EntryID) cron.Entry {
 	return task.opts.task.Entry(entryID)
-
 }
 
-// UpdateJob update or create job
+// UpdateJob updates or creates a scheduled job.
 func UpdateJob(key string, spec string, job cron.Job) error {
-	var err error
 	entryID, entrySpec, _, ok, _ := task.opts.storage.Get(key)
 	if ok && spec != entrySpec && entryID != 0 {
 		task.opts.task.Remove(entryID)
-		entryID, err = task.opts.task.AddJob(spec, job)
+		newEntryID, err := task.opts.task.AddJob(spec, job)
 		if err != nil {
 			slog.Error("task update job error", slog.Any("err", err))
 			return err
 		}
-		return task.opts.storage.Update(key, entryID)
+		return task.opts.storage.Update(key, newEntryID)
 	}
 	if ok && entryID != 0 {
 		return nil
 	}
-	entryID, err = task.opts.task.AddJob(spec, job)
+	newEntryID, err := task.opts.task.AddJob(spec, job)
 	if err != nil {
 		slog.Error("task add job error", slog.Any("err", err))
 		return err
 	}
-	return task.opts.storage.Update(key, entryID)
+	return task.opts.storage.Update(key, newEntryID)
 }
 
-// RemoveJob remove job
+// RemoveJob removes a scheduled job.
 func RemoveJob(key string) error {
 	entryID, _, _, ok, _ := task.opts.storage.Get(key)
 	if !ok {
@@ -79,52 +78,92 @@ func RemoveJob(key string) error {
 	return task.opts.storage.Remove(key)
 }
 
-// Options set options
+// Options applies task options before Start.
 func (e *Server) Options(opts ...Option) {
-	for _, o := range opts {
-		o(&e.opts)
+	e.mux.Lock()
+	defer e.mux.Unlock()
+	if e.started {
+		return
+	}
+	for _, option := range opts {
+		if option != nil {
+			option(&e.opts)
+		}
 	}
 }
 
-// String server name
+// String returns the server name.
 func (e *Server) String() string {
 	return "task"
 }
 
-// Start server
+// Start loads jobs, starts cron, and blocks until ctx is cancelled and running
+// jobs have completed.
 func (e *Server) Start(ctx context.Context) error {
-	var err error
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	e.mux.Lock()
+	if e.started {
+		e.mux.Unlock()
+		return ErrAlreadyStarted
+	}
 	e.ctx = ctx
-	keys, _ := e.opts.storage.ListKeys()
-	for i := range keys {
-		_, spec, job, ok, _ := e.opts.storage.Get(keys[i])
+
+	keys, err := e.opts.storage.ListKeys()
+	if err != nil {
+		e.mux.Unlock()
+		return err
+	}
+	for _, key := range keys {
+		_, spec, job, ok, getErr := e.opts.storage.Get(key)
+		if getErr != nil {
+			e.mux.Unlock()
+			return getErr
+		}
 		if !ok {
 			continue
 		}
-		entryID, err := e.opts.task.AddJob(spec, job)
-		if err != nil {
-			slog.ErrorContext(ctx, "task add job error", slog.Any("err", err))
-			return err
+		entryID, addErr := e.opts.task.AddJob(spec, job)
+		if addErr != nil {
+			e.mux.Unlock()
+			slog.ErrorContext(ctx, "task add job error", slog.Any("err", addErr))
+			return addErr
 		}
-		err = e.opts.storage.Update(keys[i], entryID)
-		if err != nil {
-			slog.ErrorContext(ctx, "task update job error", slog.Any("err", err))
-			return err
+		if updateErr := e.opts.storage.Update(key, entryID); updateErr != nil {
+			e.mux.Unlock()
+			slog.ErrorContext(ctx, "task update job error", slog.Any("err", updateErr))
+			return updateErr
 		}
 	}
-	go func() {
-		e.opts.task.Run()
-		<-ctx.Done()
-		err = e.Shutdown(ctx)
-		if err != nil {
-			slog.ErrorContext(ctx, e.String()+" Server shutdown error", slog.Any("err", err.Error()))
-		}
-	}()
-	return nil
+
+	e.started = true
+	e.opts.task.Start()
+	e.mux.Unlock()
+
+	<-ctx.Done()
+	return e.Shutdown(context.Background())
 }
 
-// Shutdown server
-func (e *Server) Shutdown(_ context.Context) error {
-	e.opts.task.Stop()
-	return nil
+// Shutdown stops scheduling new work and waits for running jobs to finish.
+func (e *Server) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	e.mux.Lock()
+	started := e.started
+	cronServer := e.opts.task
+	e.mux.Unlock()
+	if !started || cronServer == nil {
+		return nil
+	}
+
+	stopped := cronServer.Stop()
+	select {
+	case <-stopped.Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/mss-boot/core/server/task/server_test.go
+++ b/mss-boot/core/server/task/server_test.go
@@ -1,103 +1,63 @@
 package task
 
-/*
- * @Author: lwnmengjing<lwnmengjing@qq.com>
- * @Date: 2023/4/30 10:33:36
- * @Last Modified by: lwnmengjing<lwnmengjing@qq.com>
- * @Last Modified time: 2023/4/30 10:33:36
- */
-
 import (
 	"context"
-	"fmt"
+	"errors"
 	"testing"
 	"time"
 )
 
-var chanResult = make(chan string, 4)
-
-type testJob struct {
-	key string
-}
-
-func (t *testJob) Run() {
-	fmt.Printf("%v test job run: %s\n", time.Now(), t.key)
+func TestStartBlocksUntilCancellation(t *testing.T) {
+	srv := &Server{opts: setDefaultOption()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
 	go func() {
-		chanResult <- t.key
+		done <- srv.Start(ctx)
 	}()
+
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned before cancellation: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("task shutdown failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("task server did not stop")
+	}
 }
 
-// TestNew non-blocking test
-func TestNew(t *testing.T) {
-	type args struct {
-		opts []Option
+func TestStartCanOnlyRunOnce(t *testing.T) {
+	srv := &Server{opts: setDefaultOption()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Start(ctx)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("first start failed: %v", err)
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantArr []string
-	}{
-		{
-			name: "test",
-			args: args{
-				opts: []Option{},
-			},
-			want:    true,
-			wantArr: []string{"a", "b", "c"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := New()
-			err := c.Start(context.TODO())
-			if (err == nil) != tt.want {
-				t.Errorf("New() error = %v, wantErr %v", err, tt.want)
-				return
-			}
-			for _, k := range tt.wantArr {
-				err = UpdateJob(fmt.Sprintf("test-%s", k), "* * * * * *", &testJob{key: k})
-				if (err == nil) != tt.want {
-					t.Errorf("New() error = %v, wantErr %v", err, tt.want)
-					return
-				}
-			}
-			var count int
-			for r := range chanResult {
-				count++
-				var ok bool
-				for _, k := range tt.wantArr {
-					if r == k {
-						t.Logf("New() success, wantArr %v", tt.wantArr)
-						ok = true
-						break
-					}
-				}
-				if !ok {
-					t.Errorf("New() error, wantArr %v", tt.wantArr)
-					return
-				}
-				if count == len(tt.wantArr) {
-					break
-				}
-			}
-			for i := range tt.wantArr {
-				count++
-				if i == len(tt.wantArr)-1 {
-					break
-				}
-				err = RemoveJob(fmt.Sprintf("test-%s", tt.wantArr[i]))
-				if (err == nil) != tt.want {
-					t.Errorf("New() error = %v, wantErr %v", err, tt.want)
-					return
-				}
-			}
-			k := <-chanResult
-			t.Logf("Print %s", k)
-			if count-1 < len(tt.wantArr) {
-				t.Errorf("New() error, wantArr %v", tt.wantArr)
-				return
-			}
-		})
+	if err := srv.Start(context.Background()); !errors.Is(err, ErrAlreadyStarted) {
+		t.Fatalf("expected ErrAlreadyStarted, got %v", err)
 	}
 }
+
+func TestStartReturnsInvalidScheduleError(t *testing.T) {
+	srv := &Server{opts: setDefaultOption()}
+	WithSchedule("invalid", "not-a-cron-expression", testJob{})(&srv.opts)
+	if err := srv.Start(context.Background()); err == nil {
+		t.Fatal("expected invalid schedule error")
+	}
+}
+
+type testJob struct{}
+
+func (testJob) Run() {}

--- a/mss-boot/core/server/task/shutdown_test.go
+++ b/mss-boot/core/server/task/shutdown_test.go
@@ -1,0 +1,63 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+type runSoonOnceSchedule struct {
+	calls atomic.Int32
+}
+
+func (s *runSoonOnceSchedule) Next(now time.Time) time.Time {
+	if s.calls.Add(1) == 1 {
+		return now.Add(time.Millisecond)
+	}
+	return now.Add(time.Hour)
+}
+
+func TestTaskStartReturnsWhenShutdownTimeoutExpires(t *testing.T) {
+	srv := &Server{opts: setDefaultOption()}
+	WithShutdownTimeout(20 * time.Millisecond)(&srv.opts)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv.opts.task.Schedule(&runSoonOnceSchedule{}, cron.FuncJob(func() {
+		select {
+		case <-started:
+		default:
+			close(started)
+		}
+		<-release
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Start(ctx)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("scheduled job did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		close(release)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected shutdown deadline error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("task server did not honor shutdown timeout")
+	}
+}

--- a/mss-boot/core/server/task/storage.go
+++ b/mss-boot/core/server/task/storage.go
@@ -1,19 +1,13 @@
 package task
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/robfig/cron/v3"
 )
 
-/*
- * @Author: lwnmengjing<lwnmengjing@qq.com>
- * @Date: 2023/12/5 16:56:16
- * @Last Modified by: lwnmengjing<lwnmengjing@qq.com>
- * @Last Modified time: 2023/12/5 16:56:16
- */
-
-// Storage storage interface
+// Storage persists scheduled-job metadata.
 type Storage interface {
 	Get(key string) (entryID cron.EntryID, spec string, job cron.Job, exist bool, err error)
 	Set(key string, entryID cron.EntryID, spec string, job cron.Job) error
@@ -24,16 +18,18 @@ type Storage interface {
 
 type defaultStorage struct {
 	schedules map[string]*schedule
-	mux       sync.Mutex
+	mux       sync.RWMutex
 }
 
-// Get schedule
+// Get returns one schedule.
 func (s *defaultStorage) Get(key string) (entryID cron.EntryID, spec string, job cron.Job, exist bool, err error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 	if s.schedules == nil {
 		return
 	}
 	item, ok := s.schedules[key]
-	if !ok {
+	if !ok || item == nil {
 		return
 	}
 	entryID = item.entryID
@@ -43,7 +39,7 @@ func (s *defaultStorage) Get(key string) (entryID cron.EntryID, spec string, job
 	return
 }
 
-// Set schedule
+// Set creates or replaces a schedule.
 func (s *defaultStorage) Set(key string, entryID cron.EntryID, spec string, job cron.Job) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
@@ -58,21 +54,26 @@ func (s *defaultStorage) Set(key string, entryID cron.EntryID, spec string, job 
 	return nil
 }
 
-// Update schedule
+// Update changes the cron entry ID for a schedule.
 func (s *defaultStorage) Update(key string, entryID cron.EntryID) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	if s.schedules == nil {
 		s.schedules = make(map[string]*schedule)
 		return nil
 	}
 	item, ok := s.schedules[key]
-	if !ok {
+	if !ok || item == nil {
 		return nil
 	}
 	item.entryID = entryID
 	return nil
 }
 
+// Remove deletes a schedule.
 func (s *defaultStorage) Remove(key string) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
 	if s.schedules == nil {
 		return nil
 	}
@@ -80,11 +81,14 @@ func (s *defaultStorage) Remove(key string) error {
 	return nil
 }
 
-// ListKeys list keys
+// ListKeys returns schedule keys in deterministic order.
 func (s *defaultStorage) ListKeys() ([]string, error) {
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 	keys := make([]string, 0, len(s.schedules))
-	for k := range s.schedules {
-		keys = append(keys, k)
+	for key := range s.schedules {
+		keys = append(keys, key)
 	}
+	sort.Strings(keys)
 	return keys, nil
 }

--- a/mss-boot/core/server/task/storage_test.go
+++ b/mss-boot/core/server/task/storage_test.go
@@ -1,0 +1,41 @@
+package task
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestDefaultStorageReturnsDeterministicKeys(t *testing.T) {
+	storage := &defaultStorage{schedules: make(map[string]*schedule)}
+	for _, key := range []string{"z", "a", "m"} {
+		if err := storage.Set(key, 0, "@every 1s", testJob{}); err != nil {
+			t.Fatalf("set %q: %v", key, err)
+		}
+	}
+	keys, err := storage.ListKeys()
+	if err != nil {
+		t.Fatalf("list keys: %v", err)
+	}
+	if want := []string{"a", "m", "z"}; !reflect.DeepEqual(keys, want) {
+		t.Fatalf("keys = %v, want %v", keys, want)
+	}
+}
+
+func TestDefaultStorageSupportsConcurrentAccess(t *testing.T) {
+	storage := &defaultStorage{schedules: make(map[string]*schedule)}
+	var wait sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wait.Add(2)
+		go func() {
+			defer wait.Done()
+			_ = storage.Set("job", 1, "@every 1s", testJob{})
+		}()
+		go func() {
+			defer wait.Done()
+			_, _, _, _, _ = storage.Get("job")
+			_, _ = storage.ListKeys()
+		}()
+	}
+	wait.Wait()
+}

--- a/mss-boot/docs/architecture/runtime-and-request-contracts.md
+++ b/mss-boot/docs/architecture/runtime-and-request-contracts.md
@@ -47,8 +47,14 @@ contract. The manager treats a successful early return as
 - Components run concurrently.
 - The first unexpected error or early exit cancels the shared context.
 - Caller cancellation and configured process signals are normal shutdown paths.
-- The manager waits for components to return. If the configured grace period
-  expires it returns `ErrGracefulShutdownTimeout`.
+- The manager waits for components to return and joins real errors returned
+  during shutdown. A matching `context.Canceled` result is treated as normal;
+  flush, close, and component deadline errors remain visible to the caller.
+- If the configured outer grace period expires, the manager returns
+  `ErrGracefulShutdownTimeout`.
+- The default outer grace period is 30 seconds. It is deliberately longer than
+  built-in component shutdown deadlines. Custom configurations should preserve
+  this hierarchy so component-specific errors can be returned first.
 - A manager instance can be started once. Additions after start are ignored for
   compatibility with the existing `Add` signature, which cannot return an
   error.
@@ -116,6 +122,11 @@ The task server loads stored schedules, starts cron, waits for cancellation,
 and then waits for running jobs to complete. The default in-memory storage uses
 a read/write lock and sorted key enumeration so concurrent access and startup
 order are deterministic.
+
+Task shutdown has an independent configurable timeout. The default is five
+seconds. When a running cron job does not finish before that deadline, `Start`
+returns `context.DeadlineExceeded`; the outer manager then reports the component
+shutdown failure instead of waiting forever.
 
 The current process-wide task singleton is retained for compatibility. Replacing
 it with instance-scoped schedulers is a later architectural milestone.
@@ -190,6 +201,7 @@ tighten observable behavior:
 - configured filters and pagination are now effective;
 - authentication-enabled MGM actions are now protected;
 - GET-family methods no longer read structured bodies;
+- task shutdown is bounded and can return a deadline error;
 - invalid TLS and framework configuration return errors instead of exiting.
 
 Applications should run API and integration tests before release. If an

--- a/mss-boot/docs/architecture/runtime-and-request-contracts.md
+++ b/mss-boot/docs/architecture/runtime-and-request-contracts.md
@@ -1,0 +1,237 @@
+# Runtime and request contracts
+
+Status: accepted for the pre-v1 runtime-hardening line.
+
+This document defines observable framework behavior. Tests are the executable
+specification; this document explains the intended architecture and migration
+impact.
+
+## Goals
+
+The runtime must be predictable under cancellation and failure, adapters must
+return errors instead of terminating the process, request decoding must be
+deterministic, and authentication settings must behave consistently across
+providers.
+
+The hardening work deliberately preserves public constructor and option shapes
+where possible. It fixes correctness before attempting a physical multi-module
+split.
+
+## 1. Component lifecycle
+
+A managed component implements:
+
+```go
+type Runnable interface {
+    fmt.Stringer
+    Start(context.Context) error
+}
+```
+
+`Start` is a blocking operation. It returns only when one of these events
+occurs:
+
+1. the supplied context is cancelled and owned resources have stopped;
+2. the component encounters an unrecoverable runtime error;
+3. the component exits normally because its underlying service was explicitly
+   stopped.
+
+A component that spawns background work and immediately returns violates the
+contract. The manager treats a successful early return as
+`ErrRunnableStopped`, cancels every peer, and reports the unexpected exit.
+
+### Manager behavior
+
+- Registrations have deterministic insertion order. Replacing a component with
+  the same name preserves its original position.
+- Components run concurrently.
+- The first unexpected error or early exit cancels the shared context.
+- Caller cancellation and configured process signals are normal shutdown paths.
+- The manager waits for components to return. If the configured grace period
+  expires it returns `ErrGracefulShutdownTimeout`.
+- A manager instance can be started once. Additions after start are ignored for
+  compatibility with the existing `Add` signature, which cannot return an
+  error.
+
+The application entry point should normally own operating-system signals:
+
+```go
+ctx, stop := signal.NotifyContext(
+    context.Background(),
+    os.Interrupt,
+    syscall.SIGTERM,
+)
+defer stop()
+
+manager := server.New(server.WithoutSignalHandling())
+if err := manager.Start(ctx); err != nil {
+    return err
+}
+```
+
+Default manager signal handling remains available for existing applications.
+
+## 2. HTTP lifecycle and safety defaults
+
+The HTTP adapter creates the listening socket before reporting that it has
+started. Listen and serve failures are returned to the manager.
+
+Default defensive timeouts are non-zero:
+
+- read-header timeout;
+- full-request read timeout;
+- response write timeout;
+- keep-alive idle timeout;
+- graceful-shutdown timeout.
+
+Granular duration options are preferred. The legacy integer `WithTimeout`
+option remains supported and applies the supplied seconds to all timeout
+categories.
+
+On cancellation, the adapter calls `http.Server.Shutdown` with a fresh shutdown
+context. If the deadline expires it calls `Close`, waits for the serve loop to
+return, and joins relevant errors. A configured end hook runs before `Start`
+returns.
+
+Certificate and private-key paths are an all-or-nothing pair. Partial TLS
+configuration is rejected before binding a socket.
+
+## 3. gRPC lifecycle and process ownership
+
+The gRPC adapter follows the same blocking contract. It returns listen and
+serve errors, performs `GracefulStop`, and calls `Stop` if the independent
+shutdown deadline expires.
+
+Framework construction must not call `os.Exit` or `log.Fatal`. TLS-loading
+errors are retained by the compatibility constructor and returned by `Start`.
+Duplicate registration of the shared Prometheus collector is accepted without
+panic; callers can provide an isolated registry or disable registration.
+
+Server reflection remains enabled by default for compatibility and can be
+disabled with `WithReflection(false)` in production environments.
+
+## 4. Scheduled tasks
+
+The task server loads stored schedules, starts cron, waits for cancellation,
+and then waits for running jobs to complete. The default in-memory storage uses
+a read/write lock and sorted key enumeration so concurrent access and startup
+order are deterministic.
+
+The current process-wide task singleton is retained for compatibility. Replacing
+it with instance-scoped schedulers is a later architectural milestone.
+
+## 5. Request binding
+
+The binding pipeline is deterministic:
+
+1. URI parameters;
+2. query values and declared form fields;
+3. at most one body binder selected from the request media type;
+4. one validation pass over the completed DTO.
+
+`GET`, `HEAD`, and `OPTIONS` never consume JSON, XML, or YAML bodies. A POST,
+PUT, or PATCH request can combine query values with a JSON/XML/YAML body. Form
+and multipart media types use Gin's form binder rather than falling through to
+JSON.
+
+Binding plans are cached by reflected type, returned as defensive copies, and
+safe for concurrent use. Validation translations are registered once and
+translated error fields are emitted in stable order.
+
+## 6. Controller authentication
+
+Authentication is action-specific because `WithNoAuthAction` can exempt one
+operation while protecting others. Controller-level middleware is therefore
+attached once to each action, not both to the router group and the action.
+
+The following providers share the same rules:
+
+- GORM;
+- MongoDB/MGM;
+- Kubernetes;
+- custom actions registered through `WithAction`.
+
+When `WithAuth(true)` applies, authentication middleware runs before the
+provider handler. If the global `response.AuthHandler` compatibility hook is
+nil, the request is rejected with an internal configuration error. It is never
+silently registered as an anonymous endpoint.
+
+Long term, authentication should become an instance dependency instead of a
+global variable. The fail-closed compatibility bridge prevents unsafe behavior
+until that migration is complete.
+
+## 7. GORM search semantics
+
+Search creates a base query from:
+
+- the selected table/resolver;
+- request-derived conditions;
+- an optional request-aware custom scope.
+
+The row query adds pagination and optional tree preloads. The count query
+rebuilds the same base filters without pagination. This ensures total and rows
+represent the same data set.
+
+Search validates required configuration, reports an uninitialized database,
+checks row iteration and close errors, and safely copies result models.
+
+The reflection query resolver descends only into nested structs. Scalar
+pagination fields, nil pointers, invalid values, and short `between` ranges are
+ignored rather than panicking. Search-tagged string operations are applied only
+to string values, and `isnull` emits valid `IS NULL` SQL.
+
+## 8. Compatibility and rollback
+
+These changes preserve exported function names and most option signatures but
+tighten observable behavior:
+
+- custom runnables must block;
+- HTTP and gRPC starts no longer return immediately;
+- configured filters and pagination are now effective;
+- authentication-enabled MGM actions are now protected;
+- GET-family methods no longer read structured bodies;
+- invalid TLS and framework configuration return errors instead of exiting.
+
+Applications should run API and integration tests before release. If an
+application depended on ignored authentication, filters, or lifecycle errors,
+roll back the complete hardening change set rather than selectively reverting
+one adapter.
+
+## 9. Verification gates
+
+The independent module gate is:
+
+```bash
+cd mss-boot
+GOWORK=off go test -race -shuffle=on -count=1 ./...
+GOWORK=off go vet ./...
+GOWORK=off go mod tidy
+git diff --exit-code -- go.mod go.sum
+```
+
+The monorepo gate additionally runs application tests and a backend build.
+External-service integration tests must explicitly skip when credentials or
+services are absent.
+
+## 10. Roadmap toward a stable v1
+
+The current hardening removes several blocking correctness and security issues,
+but it is not the final architecture. The highest-value remaining work is:
+
+1. replace process-wide database, authentication, response, cache, and task
+   globals with explicit instance dependencies;
+2. make database opening return an owned handle and errors, remove library-level
+   exits, verify RDS TLS identities, and refresh IAM tokens per physical
+   connection;
+3. invert configuration-source dependencies through a registered `Source`
+   interface with context-aware load, watch, and close behavior;
+4. separate provider-specific controllers and repository adapters from the HTTP
+   contract instead of extending a central provider switch;
+5. introduce typed public errors that separate client-safe messages from
+   internal causes;
+6. enforce measured coverage thresholds and real integration matrices before
+   claiming them;
+7. split adapter modules only after dependency direction is clean and stable.
+
+These milestones address the remaining architecture-boundary and global-state
+risk without destabilizing the correctness fixes in this line.

--- a/mss-boot/examples/basic-http/main.go
+++ b/mss-boot/examples/basic-http/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/core/server/listener"
+)
+
+func main() {
+	ctx, stop := signal.NotifyContext(
+		context.Background(),
+		os.Interrupt,
+		syscall.SIGTERM,
+	)
+	defer stop()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok\n"))
+	})
+
+	manager := server.New(server.WithoutSignalHandling())
+	manager.Add(listener.New(
+		listener.WithAddr(":8080"),
+		listener.WithHandler(mux),
+	))
+
+	if err := manager.Start(ctx); err != nil {
+		slog.Error("server stopped unexpectedly", "error", err)
+		os.Exit(1)
+	}
+}

--- a/mss-boot/pkg/config/storage/queue/memory_test.go
+++ b/mss-boot/pkg/config/storage/queue/memory_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sync"
 	"testing"
 	"time"
 
@@ -14,25 +13,17 @@ import (
 )
 
 func TestMemory_Append(t *testing.T) {
-	type fields struct {
-		items *sync.Map
-		queue *sync.Map
-		wait  sync.WaitGroup
-		mutex sync.RWMutex
-	}
 	type args struct {
 		name    string
 		message storage.Messager
 	}
 	tests := []struct {
 		name    string
-		fields  fields
 		args    args
 		wantErr bool
 	}{
 		{
 			"test01",
-			fields{},
 			args{
 				name: "test",
 				message: &Message{
@@ -60,24 +51,16 @@ func TestMemory_Append(t *testing.T) {
 
 func TestMemory_Register(t *testing.T) {
 	log.SetFlags(19)
-	type fields struct {
-		items *sync.Map
-		queue *sync.Map
-		wait  sync.WaitGroup
-		mutex sync.RWMutex
-	}
 	type args struct {
 		name string
 		f    storage.ConsumerFunc
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name string
+		args args
 	}{
 		{
 			"test01",
-			fields{},
 			args{
 				name: "test",
 				f: func(message storage.Messager) error {

--- a/mss-boot/pkg/response/actions/gorm/search.go
+++ b/mss-boot/pkg/response/actions/gorm/search.go
@@ -1,12 +1,5 @@
 package gorm
 
-/*
- * @Author: lwnmengjing<lwnmengjing@qq.com>
- * @Date: 2023/3/9 00:57:48
- * @Last Modified by: lwnmengjing<lwnmengjing@qq.com>
- * @Last Modified time: 2023/3/9 00:57:48
- */
-
 import (
 	"context"
 	"errors"
@@ -14,41 +7,40 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
-	"gorm.io/plugin/dbresolver"
-
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/config/gormdb"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/search/gorms"
+	"gorm.io/gorm"
+	"gorm.io/plugin/dbresolver"
 )
 
-// Search action
+// Search is the GORM-backed list action.
 type Search struct {
 	opts *Options
 }
 
-// String action name
+// String returns the action name.
 func (*Search) String() string {
 	return "search"
 }
 
-// NewSearch new search action
+// NewSearch creates a search action.
 func NewSearch(opts ...Option) *Search {
 	o := &Options{}
 	for _, opt := range opts {
-		opt(o)
+		if opt != nil {
+			opt(o)
+		}
 	}
-	return &Search{
-		opts: o,
-	}
+	return &Search{opts: o}
 }
 
-// Handler action handler
+// Handler returns the action middleware chain.
 func (e *Search) Handler() gin.HandlersChain {
 	h := func(c *gin.Context) {
-		if e.opts.Model == nil {
-			response.Make(c).Err(http.StatusNotImplemented, "not implemented")
+		if e.opts.Model == nil || e.opts.Search == nil {
+			response.Make(c).Err(http.StatusNotImplemented, "search model is not configured")
 			return
 		}
 		e.search(c)
@@ -64,16 +56,29 @@ func (e *Search) Handler() gin.HandlersChain {
 }
 
 func (e *Search) search(c *gin.Context) {
-	req := pkg.DeepCopy(e.opts.Search).(response.Searcher)
+	req, ok := pkg.DeepCopy(e.opts.Search).(response.Searcher)
+	if !ok || req == nil {
+		response.Make(c).Err(http.StatusInternalServerError, "invalid search configuration")
+		return
+	}
 	api := response.Make(c).Bind(req)
 	if api.Error != nil {
 		api.Err(http.StatusUnprocessableEntity)
 		return
 	}
 	m := pkg.TablerDeepCopy(e.opts.Model)
+	if m == nil {
+		api.AddError(errors.New("invalid search model"))
+		api.Err(http.StatusInternalServerError)
+		return
+	}
+	if gormdb.DB == nil {
+		api.AddError(errors.New("GORM database is not initialized"))
+		api.Err(http.StatusServiceUnavailable)
+		return
+	}
 
 	db := gormdb.DB.WithContext(context.WithValue(c, "gorm:cache:tag", m.TableName()))
-
 	if e.opts.BeforeSearch != nil {
 		if err := e.opts.BeforeSearch(c, db, m); err != nil {
 			api.AddError(err).Log.Error("BeforeSearch error")
@@ -81,23 +86,25 @@ func (e *Search) search(c *gin.Context) {
 			return
 		}
 	}
-	var count int64
 
-	scopes := []func(db *gorm.DB) *gorm.DB{
-		gorms.MakeCondition(req),
-		gorms.Paginate(int(req.GetPageSize()), int(req.GetPage())),
-	}
-
-	query := db.Model(m)
-
+	filterScopes := []func(*gorm.DB) *gorm.DB{gorms.MakeCondition(req)}
 	if e.opts.Scope != nil {
-		scopes = append(scopes, e.opts.Scope(c, m))
-		query = query.Clauses(dbresolver.Use(m.TableName())).Scopes(scopes...)
+		if scope := e.opts.Scope(c, m); scope != nil {
+			filterScopes = append(filterScopes, scope)
+		}
 	}
+
+	baseQuery := func() *gorm.DB {
+		return db.
+			Clauses(dbresolver.Use(m.TableName())).
+			Model(m).
+			Scopes(filterScopes...)
+	}
+	query := baseQuery().Scopes(gorms.Paginate(int(req.GetPageSize()), int(req.GetPage())))
 
 	if e.opts.TreeField != "" && e.opts.Depth > 0 {
-		treeFields := make([]string, 0, e.opts.Depth)
-		for i := range e.opts.Depth {
+		treeFields := make([]string, e.opts.Depth)
+		for i := range treeFields {
 			treeFields[i] = e.opts.TreeField
 		}
 		query = query.Preload(strings.Join(treeFields, "."))
@@ -109,23 +116,35 @@ func (e *Search) search(c *gin.Context) {
 		api.Err(http.StatusInternalServerError)
 		return
 	}
-	defer rows.Close()
 	items := make([]any, 0, req.GetPageSize())
 	for rows.Next() {
-		m = pkg.TablerDeepCopy(e.opts.Model)
-		err = db.ScanRows(rows, m)
-		if err != nil {
-			api.AddError(err).Log.ErrorContext(c, "search error", "error", err)
+		item := pkg.TablerDeepCopy(e.opts.Model)
+		if item == nil {
+			_ = rows.Close()
+			api.AddError(errors.New("invalid search model copy"))
 			api.Err(http.StatusInternalServerError)
 			return
 		}
-		items = append(items, m)
+		if err = query.ScanRows(rows, item); err != nil {
+			_ = rows.Close()
+			api.AddError(err).Log.ErrorContext(c, "search scan error", "error", err)
+			api.Err(http.StatusInternalServerError)
+			return
+		}
+		items = append(items, item)
+		m = item
 	}
-	err = query.Scopes(func(db *gorm.DB) *gorm.DB {
-		return db.Limit(-1).Offset(-1)
-	}).Count(&count).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		api.AddError(err).Log.ErrorContext(c, "search error", "error", err)
+	rowsErr := rows.Err()
+	closeErr := rows.Close()
+	if err = errors.Join(rowsErr, closeErr); err != nil {
+		api.AddError(err).Log.ErrorContext(c, "search rows error", "error", err)
+		api.Err(http.StatusInternalServerError)
+		return
+	}
+
+	var count int64
+	if err = baseQuery().Count(&count).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		api.AddError(err).Log.ErrorContext(c, "search count error", "error", err)
 		api.Err(http.StatusInternalServerError)
 		return
 	}

--- a/mss-boot/pkg/response/actions/gorm/search_test.go
+++ b/mss-boot/pkg/response/actions/gorm/search_test.go
@@ -1,0 +1,89 @@
+package gorm
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/config/gormdb"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions"
+	"gorm.io/gorm"
+)
+
+type searchRecord struct {
+	ID   int64  `json:"id" gorm:"primaryKey"`
+	Name string `json:"name"`
+}
+
+func (*searchRecord) TableName() string {
+	return "search_records"
+}
+
+type searchRequest struct {
+	actions.Pagination
+}
+
+func TestSearchAppliesPaginationWithoutCustomScope(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite db: %v", err)
+	}
+	if err := db.AutoMigrate(&searchRecord{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	for _, record := range []searchRecord{{Name: "one"}, {Name: "two"}, {Name: "three"}} {
+		if err := db.Create(&record).Error; err != nil {
+			t.Fatalf("create record: %v", err)
+		}
+	}
+
+	previousDB := gormdb.DB
+	gormdb.DB = db
+	defer func() { gormdb.DB = previousDB }()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	action := NewSearch(
+		WithModel(&searchRecord{}),
+		WithSearch(&searchRequest{}),
+	)
+	router.GET("/records", action.Handler()...)
+
+	request := httptest.NewRequest(http.MethodGet, "/records?current=2&pageSize=1", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", response.Code, response.Body.String())
+	}
+
+	var body struct {
+		Total    int64          `json:"total"`
+		Current  int64          `json:"current"`
+		PageSize int64          `json:"pageSize"`
+		Data     []searchRecord `json:"data"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Total != 3 || body.Current != 2 || body.PageSize != 1 {
+		t.Fatalf("unexpected page metadata: %+v", body)
+	}
+	if len(body.Data) != 1 || body.Data[0].ID == 0 {
+		t.Fatalf("pagination was not applied: %+v", body.Data)
+	}
+}
+
+func TestSearchRequiresModelAndRequestConfiguration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/records", NewSearch().Handler()...)
+	request := httptest.NewRequest(http.MethodGet, "/records", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", response.Code)
+	}
+}

--- a/mss-boot/pkg/response/api.go
+++ b/mss-boot/pkg/response/api.go
@@ -1,38 +1,32 @@
 package response
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/22 4:48 下午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/22 4:48 下午
- */
-
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
-
-	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/security"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
-
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/language"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/security"
 )
 
-// DefaultLanguage 默认语言
+// DefaultLanguage is used when Accept-Language is absent.
 var DefaultLanguage = "zh-CN"
 
-// AuthHandler 鉴权
+// AuthHandler is the default authentication middleware used by controllers.
 var AuthHandler gin.HandlerFunc
 
+// VerifyHandler resolves the request verifier.
 var VerifyHandler func(ctx *gin.Context) security.Verifier
 
-// API api接口
+// API contains request-scoped response state.
 type API struct {
 	Context  *gin.Context
 	Log      *slog.Logger
@@ -41,175 +35,247 @@ type API struct {
 	language string
 }
 
-// Path 路径
-func (*API) Path() string {
-	return ""
-}
+// Path returns the route path.
+func (*API) Path() string { return "" }
 
-// Handlers 路由
-func (*API) Handlers() gin.HandlersChain {
-	return []gin.HandlerFunc{}
-}
+// Handlers returns middleware registered by the API.
+func (*API) Handlers() gin.HandlersChain { return nil }
 
-// Create 创建
-func (*API) Create(c *gin.Context) {
-	c.JSON(http.StatusMethodNotAllowed, gin.H{
-		"success":      false,
-		"errorMessage": "Method Not Allowed",
-	})
-}
+// Create responds with Method Not Allowed by default.
+func (*API) Create(c *gin.Context) { methodNotAllowed(c) }
 
-// Update 更新
-func (*API) Update(c *gin.Context) {
-	c.JSON(http.StatusMethodNotAllowed, gin.H{
-		"success":      false,
-		"errorMessage": "Method Not Allowed",
-	})
-}
+// Update responds with Method Not Allowed by default.
+func (*API) Update(c *gin.Context) { methodNotAllowed(c) }
 
-// Delete 删除
-func (*API) Delete(c *gin.Context) {
-	c.JSON(http.StatusMethodNotAllowed, gin.H{
-		"success":      false,
-		"errorMessage": "Method Not Allowed",
-	})
-}
+// Delete responds with Method Not Allowed by default.
+func (*API) Delete(c *gin.Context) { methodNotAllowed(c) }
 
-// Get 获取
-func (*API) Get(c *gin.Context) {
-	c.JSON(http.StatusMethodNotAllowed, gin.H{
-		"success":      false,
-		"errorMessage": "Method Not Allowed",
-	})
-}
+// Get responds with Method Not Allowed by default.
+func (*API) Get(c *gin.Context) { methodNotAllowed(c) }
 
-// List 列表
-func (*API) List(c *gin.Context) {
-	c.JSON(http.StatusMethodNotAllowed, gin.H{
-		"success":      false,
-		"errorMessage": "Method Not Allowed",
-	})
-}
+// List responds with Method Not Allowed by default.
+func (*API) List(c *gin.Context) { methodNotAllowed(c) }
 
-// Other 其他方法
+// Other registers additional routes.
 func (*API) Other(_ *gin.RouterGroup) {}
 
-// SetEngine 设置路由组
-func (e *API) SetEngine(engine *gin.RouterGroup) {
-	e.engine = engine
-}
+// SetEngine sets the router group.
+func (e *API) SetEngine(engine *gin.RouterGroup) { e.engine = engine }
 
-// AddError 添加错误
+// AddError adds an error to the request state without losing prior causes.
 func (e *API) AddError(err error) *API {
-	if err == nil {
+	if e == nil || err == nil {
 		return e
 	}
 	if e.Error == nil {
 		e.Error = err
 	} else {
-		e.Error = fmt.Errorf("%w; %w", e.Error, err)
+		e.Error = errors.Join(e.Error, err)
 	}
-	if e.Error != nil {
-		e.Log = e.Log.With("error", e.Error)
+	if e.Log == nil {
+		e.Log = slog.Default()
 	}
+	e.Log = e.Log.With("error", e.Error)
 	return e
 }
 
-// Make 设置http上下文
+// Make sets the HTTP context on an existing API.
 func (e *API) Make(c *gin.Context) *API {
 	e.Context = c
 	e.Log = GetRequestLogger(c)
 	return e
 }
 
-// Make 设置http上下文, 返回api
+// Make creates a request-scoped API.
 func Make(c *gin.Context) *API {
-	return &API{
-		Context: c,
-		Log:     GetRequestLogger(c),
-	}
+	return &API{Context: c, Log: GetRequestLogger(c)}
 }
 
-// Bind 参数校验
+// Bind populates d from URI, query/form, and at most one request-body format,
+// then validates the fully populated object once.
 func (e *API) Bind(d any, bindings ...binding.Binding) *API {
-	var err error
+	if e == nil {
+		return e
+	}
+	if e.Context == nil || e.Context.Request == nil {
+		return e.AddError(errors.New("response: request context is nil"))
+	}
+	if d == nil {
+		return e.AddError(errors.New("response: bind destination is nil"))
+	}
 	if len(bindings) == 0 {
 		bindings = constructor.GetBindingForGin(d)
 	}
-	switch e.Context.Request.Method {
-	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		// 去除json、yaml、xml
-		for i := range bindings {
-			switch bindings[i] {
-			case binding.JSON, binding.XML, binding.YAML:
-				bindings = append(bindings[:i], bindings[i:]...)
-			}
-		}
+	bindings = normalizeBindings(e.Context.Request, bindings)
+	if e.Log == nil {
+		e.Log = slog.Default()
 	}
-	needValidateNum := len(bindings) - 1
-	for i := range bindings {
-		switch bindings[i] {
-		case nil:
-			err = e.Context.ShouldBindUri(d)
-		case binding.Query:
-			err = e.Context.ShouldBindWith(d, binding.Query)
-		default:
-			err = e.Context.ShouldBindWith(d, bindings[i])
-		}
-		if err != nil && err.Error() == "EOF" {
-			e.Log.Warn("request body is not present anymore. ")
-			err = nil
+
+	for _, requestBinding := range bindings {
+		err := e.bindWith(d, requestBinding)
+		if errors.Is(err, io.EOF) {
+			e.Log.Debug("request body is empty")
 			continue
 		}
-		if err != nil {
-			var errs validator.ValidationErrors
-			ok := errors.As(err, &errs)
-			if ok && i < needValidateNum {
-				err = nil
-				continue
-			}
-			if err != nil {
-				e.AddError(err)
-				return e
-			}
-			trans, errT := transInit(e.getAcceptLanguage())
-			if errT != nil {
-				err = fmt.Errorf(errT.Error()+", %w", err)
-				e.AddError(err)
-				return e
-			}
-			validatorErrs := errs.Translate(trans)
-			strArr := make([]string, 0)
-			for k, v := range validatorErrs {
-				strArr = append(strArr, k+":"+v)
-			}
-			if len(strArr) != 0 {
-				err = errors.New(strings.Join(strArr, ","))
-				e.AddError(err)
-				return e
-			}
+		if err == nil {
+			continue
 		}
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			// Individual binders validate partial state. Defer validation until URI,
+			// query values, and the selected body have all been applied.
+			continue
+		}
+		return e.AddError(err)
+	}
+
+	if binding.Validator == nil {
+		return e
+	}
+	if err := binding.Validator.ValidateStruct(d); err != nil {
+		return e.addValidationError(err)
 	}
 	return e
 }
 
-// Err 通常错误数据处理
+func (e *API) bindWith(destination any, requestBinding binding.Binding) error {
+	switch requestBinding {
+	case nil:
+		return e.Context.ShouldBindUri(destination)
+	case binding.Query:
+		return e.Context.ShouldBindWith(destination, binding.Query)
+	default:
+		return e.Context.ShouldBindWith(destination, requestBinding)
+	}
+}
+
+func (e *API) addValidationError(err error) *API {
+	var validationErrors validator.ValidationErrors
+	if !errors.As(err, &validationErrors) {
+		return e.AddError(err)
+	}
+	translator, translatorErr := transInit(e.getAcceptLanguage())
+	if translatorErr != nil {
+		return e.AddError(errors.Join(err, fmt.Errorf("initialize validation translator: %w", translatorErr)))
+	}
+	translated := validationErrors.Translate(translator)
+	keys := make([]string, 0, len(translated))
+	for key := range translated {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	messages := make([]string, 0, len(keys))
+	for _, key := range keys {
+		messages = append(messages, key+":"+translated[key])
+	}
+	if len(messages) == 0 {
+		return e.AddError(err)
+	}
+	return e.AddError(errors.New(strings.Join(messages, ",")))
+}
+
+func normalizeBindings(request *http.Request, candidates []binding.Binding) []binding.Binding {
+	if request == nil {
+		return nil
+	}
+
+	method := request.Method
+	bodyAllowed := method != http.MethodGet && method != http.MethodHead && method != http.MethodOptions
+	contentType := request.Header.Get("Content-Type")
+	if index := strings.IndexByte(contentType, ';'); index >= 0 {
+		contentType = contentType[:index]
+	}
+	selected := binding.Default(method, strings.TrimSpace(contentType))
+
+	result := make([]binding.Binding, 0, len(candidates))
+	bodyCandidates := make([]binding.Binding, 0, 3)
+	formCandidate := false
+	seen := make(map[string]bool)
+	appendUnique := func(item binding.Binding) {
+		key := bindingName(item)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		result = append(result, item)
+	}
+
+	for _, candidate := range candidates {
+		switch candidate {
+		case nil:
+			appendUnique(nil)
+		case binding.Query:
+			appendUnique(binding.Query)
+		case binding.Form:
+			formCandidate = true
+		case binding.JSON, binding.XML, binding.YAML:
+			bodyCandidates = append(bodyCandidates, candidate)
+		default:
+			appendUnique(candidate)
+		}
+	}
+
+	// Gin's query binder uses the `form` tag. Apply it before a body binder so
+	// form-tagged query parameters remain available on POST/PUT/PATCH requests.
+	if formCandidate {
+		appendUnique(binding.Query)
+	}
+	if !bodyAllowed {
+		return result
+	}
+	if formCandidate && (sameBinding(selected, binding.Form) || sameBinding(selected, binding.FormMultipart)) {
+		appendUnique(selected)
+	}
+
+	var bodyBinding binding.Binding
+	for _, candidate := range bodyCandidates {
+		if sameBinding(candidate, selected) {
+			bodyBinding = candidate
+			break
+		}
+	}
+	if bodyBinding == nil && len(bodyCandidates) == 1 && strings.TrimSpace(contentType) == "" {
+		// Preserve the historical ability to bind a single declared body format
+		// when clients omit Content-Type, without misreading an explicitly
+		// different media type.
+		bodyBinding = bodyCandidates[0]
+	}
+	if bodyBinding != nil {
+		appendUnique(bodyBinding)
+	}
+	return result
+}
+
+func bindingName(requestBinding binding.Binding) string {
+	if requestBinding == nil {
+		return "uri"
+	}
+	return requestBinding.Name()
+}
+
+func sameBinding(left, right binding.Binding) bool {
+	return bindingName(left) == bindingName(right)
+}
+
+// Err writes an error response.
 func (e *API) Err(code int, msg ...string) {
 	Default.Error(e.Context, code, e.Error, msg...)
 }
 
-// OK 通常成功数据处理
-func (e *API) OK(data any, msg ...string) {
+// OK writes a success response.
+func (e *API) OK(data any, _ ...string) {
 	Default.OK(e.Context, data)
 }
 
-// PageOK 分页数据处理
-func (e *API) PageOK(result any, count int64, pageIndex int64, pageSize int64, msg ...string) {
+// PageOK writes a paginated success response.
+func (e *API) PageOK(result any, count int64, pageIndex int64, pageSize int64, _ ...string) {
 	Default.PageOK(e.Context, result, count, pageIndex, pageSize)
 }
 
-// getAcceptLanguage 获取当前语言
 func (e *API) getAcceptLanguage() string {
+	if e == nil || e.Context == nil {
+		return DefaultLanguage
+	}
 	languages := language.ParseAcceptLanguage(e.Context.GetHeader("Accept-Language"), nil)
 	if len(languages) == 0 {
 		return DefaultLanguage
@@ -217,15 +283,23 @@ func (e *API) getAcceptLanguage() string {
 	return languages[0]
 }
 
-// GetRequestLogger 获取上下文提供的日志
+// GetRequestLogger returns the request logger or creates one from the trace ID.
 func GetRequestLogger(c *gin.Context) *slog.Logger {
-	if l, exist := c.Get(pkg.LoggerKey); exist {
-		log, ok := l.(*slog.Logger)
-		if ok && log != nil {
-			return log
+	if c == nil {
+		return slog.Default()
+	}
+	if loggerValue, exists := c.Get(pkg.LoggerKey); exists {
+		if logger, ok := loggerValue.(*slog.Logger); ok && logger != nil {
+			return logger
 		}
 	}
-	// 如果没有在上下文中放入logger
 	requestID := pkg.GenerateMsgIDFromContext(c)
 	return slog.Default().With(strings.ToLower(pkg.TrafficKey), requestID)
+}
+
+func methodNotAllowed(c *gin.Context) {
+	c.JSON(http.StatusMethodNotAllowed, gin.H{
+		"success":      false,
+		"errorMessage": "Method Not Allowed",
+	})
 }

--- a/mss-boot/pkg/response/api_bind_test.go
+++ b/mss-boot/pkg/response/api_bind_test.go
@@ -1,0 +1,134 @@
+package response
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+)
+
+type mixedBindRequest struct {
+	ID   string `uri:"id" binding:"required"`
+	Name string `json:"name" binding:"required"`
+}
+
+type queryAndBodyRequest struct {
+	Filter string `query:"filter" form:"filter"`
+	Name   string `query:"name" form:"name" json:"name"`
+}
+
+func TestBindCombinesURIAndBodyBeforeFinalValidation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/records/42", bytes.NewBufferString(`{"name":"acme"}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+	context.Params = gin.Params{{Key: "id", Value: "42"}}
+
+	var request mixedBindRequest
+	api := Make(context).Bind(&request)
+	if api.Error != nil {
+		t.Fatalf("bind failed: %v", api.Error)
+	}
+	if request.ID != "42" || request.Name != "acme" {
+		t.Fatalf("unexpected bind result: %+v", request)
+	}
+}
+
+func TestBindGETSkipsRequestBodyBindings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodGet, "/records?name=query", strings.NewReader("{invalid-json"))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	var request queryAndBodyRequest
+	api := Make(context).Bind(&request)
+	if api.Error != nil {
+		t.Fatalf("GET bind unexpectedly read the body: %v", api.Error)
+	}
+	if request.Name != "query" {
+		t.Fatalf("query value was not bound: %+v", request)
+	}
+}
+
+func TestBindCombinesQueryAndJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/records?filter=active", bytes.NewBufferString(`{"name":"acme"}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+
+	var request queryAndBodyRequest
+	api := Make(context).Bind(&request)
+	if api.Error != nil {
+		t.Fatalf("bind failed: %v", api.Error)
+	}
+	if request.Filter != "active" || request.Name != "acme" {
+		t.Fatalf("unexpected bind result: %+v", request)
+	}
+}
+
+func TestBindUsesDeclaredFormBodyInsteadOfJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/records", strings.NewReader("name=form-value"))
+	context.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	var request queryAndBodyRequest
+	api := Make(context).Bind(&request)
+	if api.Error != nil {
+		t.Fatalf("form bind failed: %v", api.Error)
+	}
+	if request.Name != "form-value" {
+		t.Fatalf("form value was not bound: %+v", request)
+	}
+}
+
+func TestBindReportsFinalValidationError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/records/42", bytes.NewBufferString(`{}`))
+	context.Request.Header.Set("Content-Type", "application/json")
+	context.Params = gin.Params{{Key: "id", Value: "42"}}
+
+	var request mixedBindRequest
+	api := Make(context).Bind(&request)
+	if api.Error == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(api.Error.Error(), "Name") {
+		t.Fatalf("validation error does not identify Name: %v", api.Error)
+	}
+}
+
+func TestBindingConstructorIsDeterministicAndDefensive(t *testing.T) {
+	constructor := &bindConstructor{}
+	first := constructor.GetBindingForGin(&mixedBindRequest{})
+	second := constructor.GetBindingForGin(&mixedBindRequest{})
+	want := []binding.Binding{nil, binding.JSON}
+	if !reflect.DeepEqual(first, want) {
+		t.Fatalf("binding order = %v, want %v", bindingNames(first), bindingNames(want))
+	}
+	if !reflect.DeepEqual(second, want) {
+		t.Fatalf("cached binding order = %v, want %v", bindingNames(second), bindingNames(want))
+	}
+	first[0] = binding.Query
+	third := constructor.GetBindingForGin(&mixedBindRequest{})
+	if !reflect.DeepEqual(third, want) {
+		t.Fatalf("caller mutated cached binding plan: %v", bindingNames(third))
+	}
+	if bindings := constructor.GetBindingForGin(nil); len(bindings) != 0 {
+		t.Fatalf("nil input produced bindings: %v", bindingNames(bindings))
+	}
+}
+
+func bindingNames(bindings []binding.Binding) []string {
+	names := make([]string, 0, len(bindings))
+	for _, requestBinding := range bindings {
+		names = append(names, bindingName(requestBinding))
+	}
+	return names
+}

--- a/mss-boot/pkg/response/controller/simple.go
+++ b/mss-boot/pkg/response/controller/simple.go
@@ -1,66 +1,66 @@
 package controller
 
-/*
- * @Author: lwnmengjing
- * @Date: 2023/1/26 01:22:21
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2023/1/26 01:22:21
- */
-
 import (
 	"fmt"
+	"net/http"
 	"strings"
-
-	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions/k8s"
 
 	"github.com/gin-gonic/gin"
 	"github.com/kamva/mgm/v3"
-
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions"
 	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions/gorm"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions/k8s"
 	mgmActions "github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions/mgm"
 )
 
-// Simple controller
+// Simple dispatches standard controller actions to a configured provider.
 type Simple struct {
 	Base
 	options Options
 }
 
-// NewSimple new simple
+// NewSimple creates a controller.
 func NewSimple(options ...Option) *Simple {
-	s := &Simple{
-		options: DefaultOptions(),
-	}
-	for i := range options {
-		options[i](&s.options)
+	s := &Simple{options: DefaultOptions()}
+	for _, option := range options {
+		if option != nil {
+			option(&s.options)
+		}
 	}
 	return s
 }
 
-// GetProvider get provider
+// GetProvider returns the configured model provider.
 func (e *Simple) GetProvider() fmt.Stringer {
 	return e.options.modelProvider
 }
 
-// Path route path
+// Path preserves the historical model-derived route for GORM and MongoDB
+// controllers. Kubernetes controllers without a database model fall back to
+// their resource type instead of passing nil to mgm.CollName.
 func (e *Simple) Path() string {
-	if e.options.model == nil {
-		return ""
+	if e.options.model != nil {
+		return normalizePath(mgm.CollName(e.options.model))
 	}
-	return strings.ReplaceAll(strings.ToLower(mgm.CollName(e.options.model)), "_", "-")
+	if e.options.modelProvider == actions.ModelProviderK8S {
+		return normalizePath(string(e.options.resourceType))
+	}
+	return ""
 }
 
-// Handlers return handlers
-func (e *Simple) Handlers() gin.HandlersChain {
+// Handlers is intentionally empty because authentication can vary by action.
+// Common controller middleware is attached by GetAction so it runs exactly once
+// and preserves WithNoAuthAction semantics.
+func (*Simple) Handlers() gin.HandlersChain {
 	return nil
 }
 
-// GetAction get action
+// GetAction returns an action with consistent authentication and middleware
+// semantics across built-in and custom providers.
 func (e *Simple) GetAction(key string) response.Action {
 	if action := e.options.getAction(key); action != nil {
-		return action
+		return wrapAction(action, e.actionHandlers(key))
 	}
 	switch e.options.modelProvider {
 	case actions.ModelProviderMgm:
@@ -75,21 +75,19 @@ func (e *Simple) GetAction(key string) response.Action {
 }
 
 func (e *Simple) getActionMgm(key string) response.Action {
-	b := mgmActions.Base{
-		Model: e.options.model,
-	}
+	base := mgmActions.Base{Model: e.options.model}
+	var action response.Action
 	switch key {
 	case response.Get:
-		return mgmActions.NewGet(b, e.GetKey())
+		action = mgmActions.NewGet(base, e.GetKey())
 	case response.Control:
-		return mgmActions.NewControl(b, e.GetKey())
+		action = mgmActions.NewControl(base, e.GetKey())
 	case response.Delete:
-		return mgmActions.NewDelete(b, e.GetKey())
+		action = mgmActions.NewDelete(base, e.GetKey())
 	case response.Search:
-		return mgmActions.NewSearch(b, e.options.search)
-	default:
-		return nil
+		action = mgmActions.NewSearch(base, e.options.search)
 	}
+	return wrapAction(action, e.actionHandlers(key))
 }
 
 func (e *Simple) getActionGorm(key string) response.Action {
@@ -98,7 +96,7 @@ func (e *Simple) getActionGorm(key string) response.Action {
 		gorm.WithScope(e.options.scope),
 		gorm.WithTreeField(e.options.treeField),
 		gorm.WithDepth(e.options.depth),
-		gorm.WithHandlers(e.options.handlers),
+		gorm.WithHandlers(e.commonHandlers(key)),
 		gorm.WithControlHandlers(e.options.createHandlers),
 		gorm.WithGetHandlers(e.options.getHandlers),
 		gorm.WithDeleteHandlers(e.options.deleteHandlers),
@@ -115,9 +113,6 @@ func (e *Simple) getActionGorm(key string) response.Action {
 		gorm.WithAfterSearch(e.options.afterSearch),
 		gorm.WithKey(e.GetKey()),
 		gorm.WithSearch(e.options.search),
-	}
-	if e.options.needAuth(key) {
-		opts = append(opts, gorm.WithHandlers(gin.HandlersChain{response.AuthHandler}))
 	}
 	switch key {
 	case response.Get:
@@ -137,7 +132,7 @@ func (e *Simple) getActionK8S(key string) response.Action {
 	opts := []k8s.Option{
 		k8s.WithModel(e.options.resourceModel),
 		k8s.WithResourceType(e.options.resourceType),
-		k8s.WithHandlers(e.options.handlers),
+		k8s.WithHandlers(e.commonHandlers(key)),
 		k8s.WithControlHandlers(e.options.createHandlers),
 		k8s.WithGetHandlers(e.options.getHandlers),
 		k8s.WithDeleteHandlers(e.options.deleteHandlers),
@@ -154,9 +149,6 @@ func (e *Simple) getActionK8S(key string) response.Action {
 		k8s.WithAfterSearch(e.options.resourceAfterSearch),
 		k8s.WithKey(e.GetKey()),
 	}
-	if e.options.needAuth(key) {
-		opts = append(opts, k8s.WithHandlers(gin.HandlersChain{response.AuthHandler}))
-	}
 	switch key {
 	case response.Get:
 		return k8s.NewGet(opts...)
@@ -169,4 +161,66 @@ func (e *Simple) getActionK8S(key string) response.Action {
 	default:
 		return nil
 	}
+}
+
+func (e *Simple) commonHandlers(key string) gin.HandlersChain {
+	handlers := make(gin.HandlersChain, 0, len(e.options.handlers)+1)
+	if e.options.needAuth(key) {
+		handlers = append(handlers, configuredAuthHandler())
+	}
+	handlers = append(handlers, e.options.handlers...)
+	return handlers
+}
+
+func (e *Simple) actionHandlers(key string) gin.HandlersChain {
+	handlers := e.commonHandlers(key)
+	switch key {
+	case response.Get:
+		handlers = append(handlers, e.options.getHandlers...)
+	case response.Control:
+		handlers = append(handlers, e.options.createHandlers...)
+	case response.Delete:
+		handlers = append(handlers, e.options.deleteHandlers...)
+	case response.Search:
+		handlers = append(handlers, e.options.searchHandlers...)
+	}
+	return handlers
+}
+
+func configuredAuthHandler() gin.HandlerFunc {
+	if response.AuthHandler != nil {
+		return response.AuthHandler
+	}
+	return func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
+			"success":      false,
+			"errorMessage": "authentication middleware is not configured",
+		})
+	}
+}
+
+func wrapAction(action response.Action, handlers gin.HandlersChain) response.Action {
+	if action == nil || len(handlers) == 0 {
+		return action
+	}
+	return &actionWithHandlers{
+		Action:   action,
+		handlers: append(gin.HandlersChain(nil), handlers...),
+	}
+}
+
+type actionWithHandlers struct {
+	response.Action
+	handlers gin.HandlersChain
+}
+
+func (e *actionWithHandlers) Handler() gin.HandlersChain {
+	chain := append(gin.HandlersChain(nil), e.handlers...)
+	return append(chain, e.Action.Handler()...)
+}
+
+func normalizePath(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "_", "-")
+	return strings.ToLower(name)
 }

--- a/mss-boot/pkg/response/controller/simple_test.go
+++ b/mss-boot/pkg/response/controller/simple_test.go
@@ -1,0 +1,160 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kamva/mgm/v3"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions"
+	"github.com/mss-boot-io/mss-boot-admin/mss-boot/pkg/response/actions/k8s"
+)
+
+type controllerTestModel struct {
+	mgm.DefaultModel `bson:",inline"`
+}
+
+func (*controllerTestModel) TableName() string {
+	return "Controller_Test_Records"
+}
+
+type controllerTestAction struct {
+	name    string
+	handler gin.HandlerFunc
+}
+
+func (e controllerTestAction) String() string {
+	return e.name
+}
+
+func (e controllerTestAction) Handler() gin.HandlersChain {
+	return gin.HandlersChain{e.handler}
+}
+
+func TestMongoActionFailsClosedWhenAuthHandlerIsMissing(t *testing.T) {
+	previous := response.AuthHandler
+	response.AuthHandler = nil
+	defer func() { response.AuthHandler = previous }()
+
+	controller := NewSimple(
+		WithModel(&controllerTestModel{}),
+		WithModelProvider(actions.ModelProviderMgm),
+		WithAuth(true),
+	)
+	action := controller.GetAction(response.Get)
+	if action == nil {
+		t.Fatal("expected Mongo get action")
+	}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/records/:id", action.Handler()...)
+	request := httptest.NewRequest(http.MethodGet, "/records/not-an-object-id", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("expected fail-closed 500 response, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestAuthenticationRunsBeforeProviderAction(t *testing.T) {
+	previous := response.AuthHandler
+	response.AuthHandler = func(c *gin.Context) {
+		c.AbortWithStatus(http.StatusUnauthorized)
+	}
+	defer func() { response.AuthHandler = previous }()
+
+	controller := NewSimple(
+		WithModel(&controllerTestModel{}),
+		WithModelProvider(actions.ModelProviderMgm),
+		WithAuth(true),
+	)
+	action := controller.GetAction(response.Get)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/records/:id", action.Handler()...)
+	request := httptest.NewRequest(http.MethodGet, "/records/not-an-object-id", nil)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected auth middleware to stop the action, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestPathPreservesLegacyModelNamingAndSupportsKubernetes(t *testing.T) {
+	model := &controllerTestModel{}
+	gormController := NewSimple(
+		WithModel(model),
+		WithModelProvider(actions.ModelProviderGorm),
+	)
+	wantLegacyPath := normalizePath(mgm.CollName(model))
+	if got := gormController.Path(); got != wantLegacyPath {
+		t.Fatalf("GORM path = %q, want legacy path %q", got, wantLegacyPath)
+	}
+
+	kubernetesController := NewSimple(
+		WithModelProvider(actions.ModelProviderK8S),
+		WithResourceType(k8s.CronJob),
+	)
+	if got := kubernetesController.Path(); got != "cronjob" {
+		t.Fatalf("Kubernetes path = %q", got)
+	}
+}
+
+func TestCommonMiddlewareRunsOnce(t *testing.T) {
+	calls := 0
+	controller := NewSimple(
+		WithHandlers(gin.HandlersChain{func(c *gin.Context) {
+			calls++
+			c.Next()
+		}}),
+		WithAction(controllerTestAction{
+			name: response.Get,
+			handler: func(c *gin.Context) {
+				c.Status(http.StatusNoContent)
+			},
+		}),
+	)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	group := router.Group("/records", controller.Handlers()...)
+	group.GET("", controller.GetAction(response.Get).Handler()...)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/records", nil))
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", recorder.Code)
+	}
+	if calls != 1 {
+		t.Fatalf("common middleware ran %d times, want 1", calls)
+	}
+}
+
+func TestNoAuthActionBypassesMissingGlobalAuthHandler(t *testing.T) {
+	previous := response.AuthHandler
+	response.AuthHandler = nil
+	defer func() { response.AuthHandler = previous }()
+
+	controller := NewSimple(
+		WithAuth(true),
+		WithNoAuthAction(response.Get),
+		WithAction(controllerTestAction{
+			name: response.Get,
+			handler: func(c *gin.Context) {
+				c.Status(http.StatusNoContent)
+			},
+		}),
+	)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/records", controller.GetAction(response.Get).Handler()...)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/records", nil))
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("expected unauthenticated action to run, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}

--- a/mss-boot/pkg/response/make_binding.go
+++ b/mss-boot/pkg/response/make_binding.go
@@ -1,127 +1,137 @@
 package response
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/24 10:03 上午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/24 10:03 上午
- */
-
 import (
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin/binding"
 )
 
 const (
-	_ uint8 = iota
-	json
-	xml
-	yaml
-	form
-	query
+	uri uint8 = iota
+	jsonBody
+	xmlBody
+	yamlBody
+	formBody
+	queryValues
 )
 
 var constructor = &bindConstructor{}
 
 type bindConstructor struct {
-	cache map[string][]uint8
-	mux   sync.Mutex
+	cache map[reflect.Type][]uint8
+	mux   sync.RWMutex
 }
 
+// GetBindingForGin returns a deterministic, cached binding plan for d.
 func (e *bindConstructor) GetBindingForGin(d any) []binding.Binding {
-	bs := e.getBinding(reflect.TypeOf(d).String())
-	if bs == nil {
-		// 重新构建
-		bs = e.resolve(d)
+	typeOf := indirectType(reflect.TypeOf(d))
+	if typeOf == nil || typeOf.Kind() != reflect.Struct {
+		return nil
 	}
-	gbsMap := make(map[uint8]binding.Binding)
-	for i := range bs {
-		switch bs[i] {
-		case json:
-			gbsMap[bs[i]] = binding.JSON
-		case xml:
-			gbsMap[bs[i]] = binding.XML
-		case yaml:
-			gbsMap[bs[i]] = binding.YAML
-		case form:
-			gbsMap[bs[i]] = binding.Form
-		case query:
-			gbsMap[bs[i]] = binding.Query
-		default:
-			gbsMap[bs[i]] = nil
+	bindingIDs, ok := e.getBinding(typeOf)
+	if !ok {
+		bindingIDs = resolveBindingIDs(typeOf)
+		e.setBinding(typeOf, bindingIDs)
+	}
+
+	bindings := make([]binding.Binding, 0, len(bindingIDs))
+	for _, bindingID := range bindingIDs {
+		switch bindingID {
+		case uri:
+			bindings = append(bindings, nil)
+		case queryValues:
+			bindings = append(bindings, binding.Query)
+		case formBody:
+			bindings = append(bindings, binding.Form)
+		case jsonBody:
+			bindings = append(bindings, binding.JSON)
+		case xmlBody:
+			bindings = append(bindings, binding.XML)
+		case yamlBody:
+			bindings = append(bindings, binding.YAML)
 		}
 	}
-	gbs := make([]binding.Binding, 0)
-	for k := range gbsMap {
-		gbs = append(gbs, gbsMap[k])
-	}
-	return gbs
+	return bindings
 }
 
-func (e *bindConstructor) resolve(d any) []uint8 {
-	bs := make([]uint8, 0)
-	qType := reflect.TypeOf(d)
-	if qType.Kind() == reflect.Ptr {
-		qType = qType.Elem()
+func resolveBindingIDs(root reflect.Type) []uint8 {
+	found := make(map[uint8]bool, 6)
+	visited := make(map[reflect.Type]bool)
+	inspectBindingTags(root, found, visited)
+
+	// URI and query values are applied before a request body so validation can
+	// evaluate the fully populated DTO. Body formats have a stable precedence.
+	order := []uint8{uri, queryValues, formBody, jsonBody, xmlBody, yamlBody}
+	bindings := make([]uint8, 0, len(found))
+	for _, bindingID := range order {
+		if found[bindingID] {
+			bindings = append(bindings, bindingID)
+		}
 	}
-	qValue := reflect.ValueOf(d)
-	if qValue.Kind() == reflect.Ptr {
-		qValue = qValue.Elem()
+	return bindings
+}
+
+func inspectBindingTags(typeOf reflect.Type, found map[uint8]bool, visited map[reflect.Type]bool) {
+	typeOf = indirectType(typeOf)
+	if typeOf == nil || typeOf.Kind() != reflect.Struct || visited[typeOf] {
+		return
 	}
-	var tag reflect.StructTag
-	var ok bool
-	var v string
-	for i := 0; i < qType.NumField(); i++ {
-		if qType.Field(i).Type.Kind() == reflect.Struct {
-			// 递归
-			bs = append(bs, e.resolve(qValue.Field(i).Interface())...)
-		}
-		tag = qType.Field(i).Tag
-		if v, ok = tag.Lookup("json"); ok && v != "-" {
-			bs = append(bs, json)
-		}
-		if v, ok = tag.Lookup("xml"); ok && v != "-" {
-			bs = append(bs, xml)
-		}
-		if v, ok = tag.Lookup("yaml"); ok && v != "-" {
-			bs = append(bs, yaml)
-		}
-		// if v, ok = tag.Lookup("form"); ok && v != "-" {
-		//	bs = append(bs, form)
-		//}
-		if v, ok = tag.Lookup("query"); ok && v != "-" {
-			bs = append(bs, query)
-		}
-		if v, ok = tag.Lookup("uri"); ok && v != "-" {
-			bs = append(bs, 0)
-		}
-		if t, ok := tag.Lookup("binding"); ok && strings.Contains(t, "dive") {
-			qValue := reflect.ValueOf(d)
-			bs = append(bs, e.resolve(qValue.Field(i))...)
+	visited[typeOf] = true
+	defer delete(visited, typeOf)
+
+	for i := 0; i < typeOf.NumField(); i++ {
+		field := typeOf.Field(i)
+		if field.PkgPath != "" && !field.Anonymous {
 			continue
 		}
-		if t, ok := tag.Lookup("validate"); ok && strings.Contains(t, "dive") {
-			qValue := reflect.ValueOf(d)
-			bs = append(bs, e.resolve(qValue.Field(i))...)
+		markTag(field, "uri", uri, found)
+		markTag(field, "query", queryValues, found)
+		markTag(field, "form", formBody, found)
+		markTag(field, "json", jsonBody, found)
+		markTag(field, "xml", xmlBody, found)
+		markTag(field, "yaml", yamlBody, found)
+
+		nested := indirectType(field.Type)
+		if nested != nil && nested.Kind() == reflect.Struct {
+			inspectBindingTags(nested, found, visited)
 		}
 	}
-	return bs
 }
 
-func (e *bindConstructor) getBinding(name string) []uint8 {
-	e.mux.Lock()
-	defer e.mux.Unlock()
-	return e.cache[name]
+func markTag(field reflect.StructField, key string, bindingID uint8, found map[uint8]bool) {
+	value, ok := field.Tag.Lookup(key)
+	if !ok || value == "-" {
+		return
+	}
+	found[bindingID] = true
 }
 
-func (e *bindConstructor) setBinding(name string, bs []uint8) {
+func indirectType(typeOf reflect.Type) reflect.Type {
+	for typeOf != nil && (typeOf.Kind() == reflect.Ptr || typeOf.Kind() == reflect.Slice || typeOf.Kind() == reflect.Array) {
+		typeOf = typeOf.Elem()
+	}
+	return typeOf
+}
+
+func (e *bindConstructor) getBinding(typeOf reflect.Type) ([]uint8, bool) {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	if e.cache == nil {
+		return nil, false
+	}
+	bindings, ok := e.cache[typeOf]
+	if !ok {
+		return nil, false
+	}
+	return append([]uint8{}, bindings...), true
+}
+
+func (e *bindConstructor) setBinding(typeOf reflect.Type, bindings []uint8) {
 	e.mux.Lock()
 	defer e.mux.Unlock()
 	if e.cache == nil {
-		e.cache = make(map[string][]uint8)
+		e.cache = make(map[reflect.Type][]uint8)
 	}
-	e.cache[name] = bs
+	e.cache[typeOf] = append([]uint8(nil), bindings...)
 }

--- a/mss-boot/pkg/response/return.go
+++ b/mss-boot/pkg/response/return.go
@@ -1,18 +1,12 @@
 package response
 
-import (
-	"log/slog"
-	"os"
+import "github.com/gin-gonic/gin"
 
-	"github.com/gin-gonic/gin"
-)
-
-// Default 默认返回
+// Default is the process-wide response renderer retained for compatibility.
 var Default Responses = &response{}
 
 func checkContext(c *gin.Context) {
 	if c == nil {
-		slog.Error("context is nil, please check, e.g. e.Make(c) add your controller function")
-		os.Exit(-1)
+		panic("response: nil gin context")
 	}
 }

--- a/mss-boot/pkg/response/return_test.go
+++ b/mss-boot/pkg/response/return_test.go
@@ -1,0 +1,12 @@
+package response
+
+import "testing"
+
+func TestCheckContextPanicsInsteadOfExitingProcess(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for nil context")
+		}
+	}()
+	checkContext(nil)
+}

--- a/mss-boot/pkg/response/translate.go
+++ b/mss-boot/pkg/response/translate.go
@@ -1,14 +1,9 @@
 package response
 
-/*
- * @Author: lwnmengjing
- * @Date: 2021/6/9 10:39 上午
- * @Last Modified by: lwnmengjing
- * @Last Modified time: 2021/6/9 10:39 上午
- */
-
 import (
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/locales/en"
@@ -19,31 +14,54 @@ import (
 	chTranslations "github.com/go-playground/validator/v10/translations/zh"
 )
 
-// transInit local 通常取决于 http 请求头的 'Accept-Language'
-func transInit(local string) (trans ut.Translator, err error) {
-	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
-		zhT := zh.New() // chinese
-		enT := en.New() // english
-		uni := ut.New(enT, zhT, enT)
+var validationTranslations struct {
+	once sync.Once
+	en   ut.Translator
+	zh   ut.Translator
+	err  error
+}
 
-		var o bool
-		// register translate
-		// 注册翻译器
-		switch local {
-		case "zh", "zh-CN":
-			trans, o = uni.GetTranslator("zh")
-			if !o {
-				return nil, fmt.Errorf("uni.GetTranslator(%s) failed", "zh")
-			}
-			err = chTranslations.RegisterDefaultTranslations(v, trans)
-		default:
-			trans, o = uni.GetTranslator("en")
-			if !o {
-				return nil, fmt.Errorf("uni.GetTranslator(%s) failed", "en")
-			}
-			err = enTranslations.RegisterDefaultTranslations(v, trans)
+// transInit returns a pre-registered validator translator. Registration mutates
+// validator state, so it is performed exactly once before concurrent requests
+// begin translating validation errors.
+func transInit(locale string) (ut.Translator, error) {
+	validationTranslations.once.Do(func() {
+		engine := binding.Validator.Engine()
+		validate, ok := engine.(*validator.Validate)
+		if !ok || validate == nil {
+			validationTranslations.err = fmt.Errorf("unsupported validator engine %T", engine)
+			return
 		}
-		return
+
+		zhLocale := zh.New()
+		enLocale := en.New()
+		universal := ut.New(enLocale, zhLocale, enLocale)
+
+		var okTranslator bool
+		validationTranslations.zh, okTranslator = universal.GetTranslator("zh")
+		if !okTranslator {
+			validationTranslations.err = errors.New("validation translator zh is unavailable")
+			return
+		}
+		validationTranslations.en, okTranslator = universal.GetTranslator("en")
+		if !okTranslator {
+			validationTranslations.err = errors.New("validation translator en is unavailable")
+			return
+		}
+
+		validationTranslations.err = errors.Join(
+			chTranslations.RegisterDefaultTranslations(validate, validationTranslations.zh),
+			enTranslations.RegisterDefaultTranslations(validate, validationTranslations.en),
+		)
+	})
+	if validationTranslations.err != nil {
+		return nil, validationTranslations.err
 	}
-	return
+
+	switch locale {
+	case "zh", "zh-CN", "zh-Hans":
+		return validationTranslations.zh, nil
+	default:
+		return validationTranslations.en, nil
+	}
 }

--- a/mss-boot/pkg/response/translate_test.go
+++ b/mss-boot/pkg/response/translate_test.go
@@ -1,0 +1,38 @@
+package response
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestValidationTranslatorsAreSafeForConcurrentUse(t *testing.T) {
+	locales := []string{"zh-CN", "en-US", "zh-Hans", "en"}
+	var wait sync.WaitGroup
+	errorsCh := make(chan error, 64)
+	for i := 0; i < 64; i++ {
+		locale := locales[i%len(locales)]
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			translator, err := transInit(locale)
+			if err != nil {
+				errorsCh <- err
+				return
+			}
+			if translator == nil {
+				errorsCh <- errNilTranslator
+			}
+		}()
+	}
+	wait.Wait()
+	close(errorsCh)
+	for err := range errorsCh {
+		t.Fatalf("translator initialization failed: %v", err)
+	}
+}
+
+type nilTranslatorError struct{}
+
+func (nilTranslatorError) Error() string { return "translator is nil" }
+
+var errNilTranslator error = nilTranslatorError{}

--- a/mss-boot/pkg/search/gorms/query.go
+++ b/mss-boot/pkg/search/gorms/query.go
@@ -7,132 +7,179 @@ import (
 )
 
 const (
-	// FromQueryTag tag标记
+	// FromQueryTag marks fields that participate in generated search clauses.
 	FromQueryTag = "search"
-	// Mysql 数据库标识
+	// Mysql identifies the MySQL SQL dialect.
 	Mysql = "mysql"
-	// Postgres 数据库标识
+	// Postgres identifies the PostgreSQL SQL dialect.
 	Postgres = "postgres"
-	// Dm 数据库标识
+	// Dm identifies the DM SQL dialect.
 	Dm = "dm"
 )
 
-// ResolveSearchQuery 解析
-/**
- * 	exact / iexact 等于
- * 	contains / icontains 包含
- *	gt / gte 大于 / 大于等于
- *	lt / lte 小于 / 小于等于
- *	startswith / istartswith 以…起始
- *	endswith / iendswith 以…结束
- *	between 范围     e.g. receiveAt[]=2021-01-01&receiveAt[]=2021-01-02
- *	in
- *	isnull
- *  order 排序		e.g. order[key]=desc     order[key]=asc
- */
-func ResolveSearchQuery(driver string, q any, condition Condition) {
-	qType := reflect.TypeOf(q)
-	qValue := reflect.ValueOf(q)
-	if qType.Kind() == reflect.Ptr {
-		qType = qType.Elem()
+// ResolveSearchQuery translates search-tagged fields into Condition calls.
+//
+// Fields without a search tag are traversed only when they are nested structs.
+// Invalid, nil, or unsupported values are ignored instead of panicking because
+// this function is used on request DTOs that commonly embed pagination and
+// other non-search fields.
+func ResolveSearchQuery(driver string, query any, condition Condition) {
+	if query == nil || condition == nil {
+		return
 	}
-	if qValue.Kind() == reflect.Ptr {
-		qValue = qValue.Elem()
-	}
-	var t *resolveSearchTag
 
-	for i := 0; i < qType.NumField(); i++ {
-		tag, ok := qType.Field(i).Tag.Lookup(FromQueryTag)
-		if !ok {
-			// 递归调用
-			ResolveSearchQuery(driver, qValue.Field(i).Interface(), condition)
-			continue
-		}
-		switch tag {
-		case "-":
-			continue
-		}
-		t = makeTag(tag)
-		if qValue.Field(i).IsZero() {
+	queryValue, ok := indirectValue(reflect.ValueOf(query))
+	if !ok || queryValue.Kind() != reflect.Struct {
+		return
+	}
+	queryType := queryValue.Type()
+
+	for i := 0; i < queryType.NumField(); i++ {
+		structField := queryType.Field(i)
+		fieldValue := queryValue.Field(i)
+		if structField.PkgPath != "" && !structField.Anonymous {
+			// Unexported fields cannot be converted to interface values safely.
 			continue
 		}
 
-		parseSQL(driver, t, condition, qValue, i)
+		tag, tagged := structField.Tag.Lookup(FromQueryTag)
+		if !tagged {
+			if fieldValue.CanInterface() && isNestedStruct(fieldValue) {
+				ResolveSearchQuery(driver, fieldValue.Interface(), condition)
+			}
+			continue
+		}
+		if tag == "-" || !fieldValue.CanInterface() || fieldValue.IsZero() {
+			continue
+		}
+
+		parseSQL(driver, makeTag(tag), condition, fieldValue)
 	}
 }
 
-func parseSQL(driver string, searchTag *resolveSearchTag, condition Condition, qValue reflect.Value, i int) {
-	var sep = "`"
-	if driver == Postgres {
-		sep = "\""
+func parseSQL(driver string, searchTag *resolveSearchTag, condition Condition, fieldValue reflect.Value) {
+	if searchTag == nil || condition == nil || searchTag.Type == "" {
+		return
 	}
 
+	separator := "`"
+	if driver == Postgres {
+		separator = "\""
+	}
 	if driver == Dm {
 		searchTag.Table = strings.ToUpper(searchTag.Table)
 		searchTag.Column = strings.ToUpper(searchTag.Column)
 	}
-	iStr := ""
+	if searchTag.Column == "" && searchTag.Type != "left" {
+		return
+	}
+
+	insensitivePrefix := ""
 	if driver == Postgres {
-		iStr = "i"
+		insensitivePrefix = "i"
 	}
-	column := fmt.Sprintf("%s%s%s", sep, searchTag.Column, sep)
+	column := fmt.Sprintf("%s%s%s", separator, searchTag.Column, separator)
 	if searchTag.Table != "" {
-		searchTag.Table = fmt.Sprintf("%s%s%s.", sep, searchTag.Table, sep)
-		column = searchTag.Table + column
+		column = fmt.Sprintf("%s%s%s.%s", separator, searchTag.Table, separator, column)
 	}
+
 	switch searchTag.Type {
 	case "left":
-		// 左关联
+		if searchTag.Join == "" || searchTag.Table == "" || len(searchTag.On) < 2 {
+			return
+		}
 		join := condition.SetJoinOn(searchTag.Type, fmt.Sprintf(
 			"left join %s%s%s on %s%s%s.%s%s%s = %s%s%s.%s%s%s",
-			sep,
+			separator,
 			searchTag.Join,
-			sep, sep,
+			separator,
+			separator,
 			searchTag.Join,
-			sep, sep,
+			separator,
+			separator,
 			searchTag.On[0],
-			sep, sep,
+			separator,
+			separator,
 			searchTag.Table,
-			sep, sep,
+			separator,
+			separator,
 			searchTag.On[1],
-			sep,
+			separator,
 		))
-		ResolveSearchQuery(driver, qValue.Field(i).Interface(), join)
-	case "exact", "iexact":
-		condition.SetWhere(fmt.Sprintf("%s = ?", column), []any{qValue.Field(i).Interface()})
-	case "contains":
-		condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{"%" + qValue.Field(i).String() + "%"})
-	case "icontains":
-		condition.SetWhere(fmt.Sprintf("%s %slike ?", column, iStr), []any{"%" + qValue.Field(i).String() + "%"})
-	case "gt":
-		condition.SetWhere(fmt.Sprintf("%s > ?", column), []any{qValue.Field(i).Interface()})
-	case "gte":
-		condition.SetWhere(fmt.Sprintf("%s >= ?", column), []any{qValue.Field(i).Interface()})
-	case "lt":
-		condition.SetWhere(fmt.Sprintf("%s < ?", column), []any{qValue.Field(i).Interface()})
-	case "lte":
-		condition.SetWhere(fmt.Sprintf("%s <= ?", column), []any{qValue.Field(i).Interface()})
-	case "startswith":
-		condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{qValue.Field(i).String() + "%"})
-	case "istartswith":
-		condition.SetWhere(fmt.Sprintf("%s %slike ?", column, iStr), []any{qValue.Field(i).String() + "%"})
-	case "endswith":
-		condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{"%" + qValue.Field(i).String()})
-	case "iendswith":
-		condition.SetWhere(fmt.Sprintf("%s %slike ?", column, iStr), []any{"%" + qValue.Field(i).String()})
-	case "in":
-		condition.SetWhere(fmt.Sprintf("%s in (?)", column), []any{qValue.Field(i).Interface()})
-	case "isnull":
-		if !qValue.Field(i).IsZero() || !qValue.Field(i).IsNil() {
-			condition.SetWhere(fmt.Sprintf("%s isnull", column), make([]any, 0))
+		if join != nil && fieldValue.CanInterface() {
+			ResolveSearchQuery(driver, fieldValue.Interface(), join)
 		}
+	case "exact", "iexact":
+		condition.SetWhere(fmt.Sprintf("%s = ?", column), []any{fieldValue.Interface()})
+	case "contains":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{"%" + fieldValue.String() + "%"})
+		}
+	case "icontains":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s %slike ?", column, insensitivePrefix), []any{"%" + fieldValue.String() + "%"})
+		}
+	case "gt":
+		condition.SetWhere(fmt.Sprintf("%s > ?", column), []any{fieldValue.Interface()})
+	case "gte":
+		condition.SetWhere(fmt.Sprintf("%s >= ?", column), []any{fieldValue.Interface()})
+	case "lt":
+		condition.SetWhere(fmt.Sprintf("%s < ?", column), []any{fieldValue.Interface()})
+	case "lte":
+		condition.SetWhere(fmt.Sprintf("%s <= ?", column), []any{fieldValue.Interface()})
+	case "startswith":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{fieldValue.String() + "%"})
+		}
+	case "istartswith":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s %slike ?", column, insensitivePrefix), []any{fieldValue.String() + "%"})
+		}
+	case "endswith":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s like ?", column), []any{"%" + fieldValue.String()})
+		}
+	case "iendswith":
+		if fieldValue.Kind() == reflect.String {
+			condition.SetWhere(fmt.Sprintf("%s %slike ?", column, insensitivePrefix), []any{"%" + fieldValue.String()})
+		}
+	case "in":
+		if fieldValue.Kind() == reflect.Slice || fieldValue.Kind() == reflect.Array {
+			condition.SetWhere(fmt.Sprintf("%s in (?)", column), []any{fieldValue.Interface()})
+		}
+	case "isnull":
+		// Zero values were filtered by ResolveSearchQuery. A non-zero flag means
+		// the caller explicitly requested the NULL predicate.
+		condition.SetWhere(fmt.Sprintf("%s is null", column), nil)
 	case "between":
-		condition.SetWhere(fmt.Sprintf("%s between ? and ?", column),
-			[]any{qValue.Field(i).Index(0).Interface(), qValue.Field(i).Index(1).Interface()})
+		if (fieldValue.Kind() == reflect.Slice || fieldValue.Kind() == reflect.Array) && fieldValue.Len() >= 2 {
+			condition.SetWhere(
+				fmt.Sprintf("%s between ? and ?", column),
+				[]any{fieldValue.Index(0).Interface(), fieldValue.Index(1).Interface()},
+			)
+		}
 	case "order":
-		switch strings.ToLower(qValue.Field(i).String()) {
-		case "desc", "asc":
-			condition.SetOrder(fmt.Sprintf("%s %s", column, qValue.Field(i).String()))
+		if fieldValue.Kind() != reflect.String {
+			return
+		}
+		direction := strings.ToLower(fieldValue.String())
+		if direction == "desc" || direction == "asc" {
+			condition.SetOrder(fmt.Sprintf("%s %s", column, direction))
 		}
 	}
+}
+
+func indirectValue(value reflect.Value) (reflect.Value, bool) {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return reflect.Value{}, false
+		}
+		value = value.Elem()
+	}
+	return value, value.IsValid()
+}
+
+func isNestedStruct(value reflect.Value) bool {
+	value, ok := indirectValue(value)
+	return ok && value.Kind() == reflect.Struct
 }

--- a/mss-boot/pkg/search/gorms/query_safety_test.go
+++ b/mss-boot/pkg/search/gorms/query_safety_test.go
@@ -1,0 +1,67 @@
+package gorms
+
+import "testing"
+
+type paginationFields struct {
+	Current  int64 `form:"current"`
+	PageSize int64 `form:"pageSize"`
+}
+
+type safeSearchQuery struct {
+	paginationFields
+	Name    string   `search:"type:contains;column:name"`
+	Missing *nestedSearch
+	Range   []int64 `search:"type:between;column:created_at"`
+	Null    bool    `search:"type:isnull;column:deleted_at"`
+}
+
+type nestedSearch struct {
+	Status string `search:"type:exact;column:status"`
+}
+
+func TestResolveSearchQueryIgnoresNonStructEmbeddedFields(t *testing.T) {
+	condition := &GormCondition{}
+	query := safeSearchQuery{
+		paginationFields: paginationFields{Current: 2, PageSize: 20},
+		Name:             "alice",
+	}
+
+	ResolveSearchQuery(Mysql, query, condition)
+
+	values, ok := condition.Where["`name` like ?"]
+	if !ok {
+		t.Fatalf("name condition was not generated: %#v", condition.Where)
+	}
+	if len(values) != 1 || values[0] != "%alice%" {
+		t.Fatalf("unexpected name condition values: %#v", values)
+	}
+	if len(condition.Where) != 1 {
+		t.Fatalf("pagination fields unexpectedly became search conditions: %#v", condition.Where)
+	}
+}
+
+func TestResolveSearchQueryHandlesNilAndMalformedValuesWithoutPanic(t *testing.T) {
+	condition := &GormCondition{}
+	query := safeSearchQuery{
+		Missing: nil,
+		Range:   []int64{1},
+	}
+
+	ResolveSearchQuery(Mysql, query, condition)
+	ResolveSearchQuery(Mysql, nil, condition)
+	ResolveSearchQuery(Mysql, int64(42), condition)
+	ResolveSearchQuery(Mysql, query, nil)
+
+	if len(condition.Where) != 0 {
+		t.Fatalf("malformed values unexpectedly generated conditions: %#v", condition.Where)
+	}
+}
+
+func TestResolveSearchQueryBuildsSafeIsNullPredicate(t *testing.T) {
+	condition := &GormCondition{}
+	ResolveSearchQuery(Mysql, safeSearchQuery{Null: true}, condition)
+
+	if _, ok := condition.Where["`deleted_at` is null"]; !ok {
+		t.Fatalf("is-null condition was not generated: %#v", condition.Where)
+	}
+}


### PR DESCRIPTION
## 目标

把 `mss-boot/` 从功能丰富但核心运行时契约不稳定的公共工具集合，推进为生命周期可证明、错误可传播、默认更安全、文档与门禁可信的开源框架模块。

基线为最新 `main`：

```text
d891cf1aea69287e11bfc7d1c9e1a90a8b16bb8c
```

当前 HEAD：

```text
5de059a127156a950516df55d1650ad81d16b4a6
```

分支相对 `main`：16 个线性提交，behind 0，无 rebase、force-push 或历史改写。

## 已完成

### 1. 运行时生命周期

- 明确 `Runnable.Start(context.Context) error` 为阻塞式生命周期契约。
- Manager 并发运行组件，确定性保存注册顺序，首个异常退出取消同组组件。
- 支持调用方 Context、兼容的 SIGINT/SIGTERM 处理、关闭超时和重复启动保护。
- 正确区分正常取消与运行时错误；汇总并返回 flush/close/shutdown 错误。
- 支持包装的 `context.Canceled` / 父 Context 错误。
- Manager 默认外层关闭期限调整为 30 秒，长于内置组件自身期限。

### 2. HTTP / gRPC / Task

- HTTP `Start` 阻塞到真实退出并传播 listen/serve 错误。
- HTTP 启用 ReadHeader、Read、Write、Idle 和 Shutdown 超时；超时后强制 Close。
- HTTP TLS 配置不完整时拒绝启动，结束 Hook 在 `Start` 返回前确定执行。
- gRPC 移除 TLS 初始化阶段 `os.Exit`、全局 tracing 修改和 `MustRegister` panic。
- 修复 `grpc.WithTimeout` 写错字段。
- gRPC reflection、Prometheus registerer 和 shutdown timeout 可配置。
- gRPC GracefulStop 受独立关闭 Context 控制，超时后调用 Stop。
- Task 真正等待 cron 停止；运行中 Job 超过独立期限时返回 `context.DeadlineExceeded`。
- 默认 Task 存储增加 RWMutex 和确定性 key 排序。

### 3. 请求、查询与鉴权

- GORM Search 无论是否有自定义 Scope，都应用请求条件与分页。
- rows 与 Count 使用相同过滤链，Count 不带分页。
- 显式处理 DB 未初始化、模型复制、scan、rows iteration/close 错误。
- 修复查询反射递归进入分页标量并 panic；保护 nil、非 struct、短 `between`、`isnull` 等边界。
- Binding 改为 URI → Query/Form → 单一媒体类型 Body → 最终一次校验。
- GET/HEAD/OPTIONS 不再读取 JSON/XML/YAML Body。
- Binding 计划缓存可并发使用并返回防御性副本。
- validator 翻译注册使用 `sync.Once`，错误字段顺序稳定。
- GORM、MGM、Kubernetes 和自定义 Action 使用统一的按 Action 鉴权规则。
- `WithAuth(true)` 在兼容 AuthHandler 缺失时 fail-closed，不再悄悄暴露匿名接口。
- 保留 `WithNoAuthAction`，并验证公共中间件只执行一次。

### 4. 文档与开源可信度

- 重写中英文 README，修正迁移后的仓库/module 路径。
- 删除不存在的 Quick Start API、未经门禁证明的覆盖率和版本声明。
- 新增参与 `go test ./...` 编译的 `examples/basic-http`。
- 新增 `docs/architecture/runtime-and-request-contracts.md`，定义生命周期、绑定、鉴权、查询与兼容契约。
- 重写 CHANGELOG 为可验证的实际变更和迁移说明。

### 5. 质量门禁

新增或强化：

```bash
cd mss-boot
GOWORK=off go test -shuffle=on -count=1 ./...
GOWORK=off go test -race -shuffle=on -count=1 ./...
GOWORK=off go vet ./...
GOWORK=off go mod tidy
git diff --exit-code -- go.mod go.sum
```

单仓 CI 还继续执行根模块测试、完整后端编译和 `go work vendor`。

## 最终验证（HEAD `5de059a`）

- CI：通过
- 全量普通单测：通过
- Framework race：通过
- Framework vet：通过
- Framework module tidy/diff：通过，零漂移
- 后端完整构建：通过
- Workspace vendor：通过
- CodeQL：通过
- govulncheck：通过
- Docs Drift：通过
- PR Guard：通过

## 兼容性影响

- 自定义 Runnable 必须阻塞到组件停止；过去启动 goroutine 后立即返回的实现会被视为异常退出。
- HTTP/gRPC `Start` 现在阻塞并返回运行时错误。
- Task `Start` 在 Job 关闭超时时可返回 `context.DeadlineExceeded`。
- 过去被忽略的 GORM 分页、查询条件和 MGM 鉴权现在真正生效。
- GET-family 请求不再从结构化 Body 绑定数据。
- GORM/MGM 路由命名保留历史 `mgm.CollName` 行为；Kubernetes 无 DB Model 时使用资源类型。

这些属于正确性和安全性收紧。若应用依赖旧的不安全行为，应整体回滚本 PR，而不是只选择性回退一个 Provider。

## 安全影响

- Auth-enabled Controller 默认拒绝而不是匿名放行。
- HTTP 默认非零 I/O 超时。
- TLS 初始化错误返回宿主应用，不再退出进程。
- 运行时关闭错误不再被吞掉。

## 尚未在本 PR 处理

本 PR 聚焦阻断级正确性、并发、安全默认值和门禁，不混入破坏性架构拆分。后续高价值工作包括：

1. 消除数据库、鉴权、响应、缓存、Task 等进程级全局状态。
2. 数据库 Open 返回 owned handle/error，移除库内退出；修复 RDS TLS 验证和每物理连接 IAM Token 刷新。
3. Config Source 使用注册式端口接口，支持 Context、Watch error、Close。
4. 拆分 Provider-specific Controller/Repository，消除核心 Provider switch。
5. 引入客户端安全 Message 与内部 Cause 分离的 typed errors。
6. 建立可执行的覆盖率阈值和真实后端集成矩阵。
7. 依赖方向清理后再拆 adapter modules。
