### PR TITLE
fix: clear V6 menu console errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,8 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'web/antd-v6/**'
-      - '.agents/**'
-      - '.codex/**'
-      - '.cursor/**'
-      - '**/*.md'
-      - '.github/workflows/agent-native-ci.yml'
-      - '.github/workflows/docs.yml'
-      - '.github/workflows/frontend-v6-ci.yml'
-      - '.github/workflows/swagger.yml'
+    # Branch protection requires the admin-ci context. Keep pull requests
+    # unfiltered so GitHub always creates that required check.
   workflow_dispatch:
 
 permissions:

--- a/docs/adr/2026-08-04-component-scoped-ci.md
+++ b/docs/adr/2026-08-04-component-scoped-ci.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-08-04
+- Amended: 2026-08-17
 - Scope: `mss-boot-admin` monorepo validation and publishing
 
 ## Context
@@ -23,7 +24,7 @@ Validation is split into component-owned workflows:
 
 | Component | Workflow | Required behavior |
 | --- | --- | --- |
-| Admin backend | `.github/workflows/ci.yml` | Root tests and root build run in parallel; the historical `CI / build` aggregate check remains available for branch protection. |
+| Admin backend | `.github/workflows/ci.yml` | Admin tests and compilation run in parallel; every pull request emits the branch-protection-required `admin-ci` aggregate check. |
 | Framework | `.github/workflows/mss-boot-ci.yml` | Independent `GOWORK=off` tests, race tests, vet, and module-tidiness checks. |
 | Frontend | `.github/workflows/frontend-v6-ci.yml` | Biome, TypeScript, Vitest, production build, delivery smoke, and browser evidence validate the sole V6 application. |
 | Documentation | `.github/workflows/docs.yml` | Dumi build on documentation changes and Cloudflare deployment only after a successful `main` build. |
@@ -31,6 +32,7 @@ Validation is split into component-owned workflows:
 
 Additional rules:
 
+- A workflow that owns a required branch-protection check must start for every pull request. Component filtering may happen inside its jobs or on non-PR events, but a required check must never disappear because of trigger-level path filters.
 - Feature branches do not run duplicate `push` workflows. Pull requests validate feature work; `push` remains for `main` and release tags.
 - Superseded pull-request runs are cancelled through workflow concurrency groups.
 - Redis-backed Go jobs use a native `redis:7-alpine` service instead of building a third-party Docker action.
@@ -42,7 +44,7 @@ Additional rules:
 
 ## Compatibility
 
-The workflow file `.github/workflows/ci.yml` keeps the workflow name `CI` and exposes a final job named `build`. Existing branch rules that require `CI / build` therefore continue to represent both root tests and root compilation.
+The workflow file `.github/workflows/ci.yml` keeps the workflow name `CI` and exposes a final job named `admin-ci`. The `main` branch rule requires that exact context, so the workflow is intentionally unfiltered for pull requests. Push and tag events remain path-scoped where no pull-request merge gate depends on them.
 
 The frontend workflow similarly keeps `Frontend CI / build` as an aggregate over quality and compilation. New framework and container checks can be made required after one successful pull-request run establishes their exact check names.
 
@@ -51,17 +53,16 @@ The frontend workflow similarly keeps `Frontend CI / build` as an aggregate over
 - Root admin tests and compilation run concurrently.
 - Framework test, race, and static/module checks run concurrently.
 - Frontend and docs jobs no longer wait behind Go validation.
-- A documentation-only pull request does not start the root or framework workflow.
-- A frontend-only pull request does not start the root, framework, or docs workflow.
+- Documentation-only and frontend-only pull requests still start the Admin workflow so the required `admin-ci` context is created; independently owned framework, frontend, and docs workflows remain path-scoped.
 - A framework change still triggers root admin compatibility validation, but the two workflows execute independently and concurrently.
-- Main-branch image publishing no longer extends the required `CI / build` duration.
+- Main-branch image publishing no longer extends the required `admin-ci` duration.
 - Dockerfile, Go dependency, and container-workflow changes fail in the pull request if workspace vendoring or the image context is invalid, instead of failing for the first time after merge.
 
 ## Validation
 
 A workflow change is complete when a pull request demonstrates:
 
-- `CI / build` succeeds;
+- `admin-ci` is created and succeeds for every pull request;
 - `mss-boot CI / mss-boot` succeeds;
 - `Frontend CI / build` succeeds when frontend paths change;
 - `Docs / build` succeeds when docs paths change;

--- a/web/antd-v6/src/modules/administration/MenuManagement.tsx
+++ b/web/antd-v6/src/modules/administration/MenuManagement.tsx
@@ -414,7 +414,7 @@ export default function MenuManagement({
           { id: 'menu.apiBinding.title' },
           { name: bindingMenu ? formatMenuLabel(intl, bindingMenu.name) : '' },
         )}
-        width={760}
+        size={760}
         extra={
           <Button
             type="primary"

--- a/web/antd-v6/src/shared/navigation/menuLocale.test.ts
+++ b/web/antd-v6/src/shared/navigation/menuLocale.test.ts
@@ -6,6 +6,9 @@ describe('menu locale normalization', () => {
     ['menu.origination.user', 'menu.origination.user'],
     ['origination.user', 'menu.origination.user'],
     ['user', 'menu.user'],
+    ['menu', 'menu.menu-management'],
+    ['authority.menu', 'menu.authority.menu'],
+    ['menu.authority.menu', 'menu.authority.menu'],
     [' menu.origination.user ', 'menu.origination.user'],
   ])('normalizes %s', (source, expected) => {
     expect(resolveMenuLocaleID(source)).toBe(expected);

--- a/web/antd-v6/src/shared/navigation/menuLocale.ts
+++ b/web/antd-v6/src/shared/navigation/menuLocale.ts
@@ -11,9 +11,25 @@ export function resolveMenuLocaleID(value: string | undefined): string {
   if (!trimmed) return '';
 
   const segments = trimmed.split('.').filter(Boolean);
-  const lastMenuIndex = segments.lastIndexOf('menu');
-  if (lastMenuIndex >= 0) return segments.slice(lastMenuIndex).join('.');
-  return `menu.${segments.join('.')}`;
+  if (!segments.length) return '';
+
+  // The authorization endpoint uses the historical leaf name `menu` for
+  // /menu, while the V6 route and locale catalog use `menu-management` to
+  // avoid colliding with the `menu.` locale namespace itself.
+  if (segments.length === 1 && segments[0] === 'menu') return 'menu.menu-management';
+  if (segments[0] !== 'menu') return `menu.${segments.join('.')}`;
+
+  // Migration-era CompleteName values can repeat the complete canonical ID.
+  // Only a later `menu` followed by the original root segment starts such a
+  // repeated ID; a final business leaf such as `menu.authority.menu` does not.
+  const rootSegment = segments[1];
+  let canonicalStart = 0;
+  for (let index = 2; index < segments.length - 1; index += 1) {
+    if (segments[index] === 'menu' && segments[index + 1] === rootSegment) {
+      canonicalStart = index;
+    }
+  }
+  return segments.slice(canonicalStart).join('.');
 }
 
 /** ProLayout prefixes route names with `menu.` when locale support is enabled. */


### PR DESCRIPTION
## What changed

- replace the deprecated Ant Design 6 Drawer `width` prop with `size` in menu API binding
- normalize historical menu names without collapsing the legitimate `menu.authority.menu` leaf to the invalid locale key `menu`
- add regression cases for the bare, qualified, and canonical menu-name forms
- ensure the branch-protection-required `admin-ci` check is created for every pull request

## Why

Post-merge qualification of PR #487 found two browser-console release blockers: an Ant Design Drawer deprecation warning and React Intl missing-message errors when opening role authorization or switching locale. The locale bug came from treating every final `menu` segment as a duplicated namespace marker, including the real menu-management leaf.

PR #488 also exposed a CI governance deadlock: `main` requires `admin-ci`, while the Admin CI workflow ignored V6-only changes, so GitHub waited forever for a check that was never created. Pull requests now start the workflow unconditionally; push-time path filtering remains unchanged.

## Impact

V6 menu API binding, role authorization, and locale switching now complete without console warnings or missing-message errors. Required Admin CI can no longer remain permanently pending for path-filtered pull requests. There is no API, database, permission, or migration change.

## Documentation impact

Updated `docs/adr/2026-08-04-component-scoped-ci.md` to record that workflows owning required branch-protection checks must start for every pull request and to document the exact `admin-ci` compatibility contract.

## Security impact

No authentication, authorization, secret handling, or trust-boundary behavior changes. Existing backend permission enforcement is unchanged.

## Release and compatibility impact

This removes two release-qualification console blockers and restores a deterministic required-check path without changing backend compatibility or migration behavior. The CI change may run the Admin suite for pull requests that previously matched only ignored paths, which is intentional to satisfy branch protection.

## Validation

- `corepack pnpm run lint`
- `corepack pnpm run test:ci` — 69 files, 228 tests passed
- focused menu locale tests — 9 passed
- `go run ./cmd/mss verify --changed` — success after the CI workflow and ADR updates
- `corepack pnpm@9.15.9 --dir docs build` — success
- Codex in-app browser: menu API drawer, role authorization tree, Chinese/English switching, localized labels, and console errors/warnings = 0
