### PR TITLE
ci: install Playwright for release readiness

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -195,6 +195,11 @@ jobs:
         if: ${{ inputs.phase == 'feature-freeze' }}
         run: corepack pnpm@10.34.5 --dir web/antd-v6 install --frozen-lockfile --ignore-scripts
 
+      - name: Install Playwright Chromium
+        if: ${{ inputs.phase == 'feature-freeze' }}
+        working-directory: web/antd-v6
+        run: corepack pnpm@10.34.5 exec playwright install --with-deps chromium
+
       - name: Install documentation dependencies
         if: ${{ inputs.phase == 'feature-freeze' }}
         run: corepack pnpm@9.15.9 --dir docs install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ topic-branch evidence is preliminary only.
 - Added a repository-wide LF checkout contract and explicit pnpm pins for the
   pnpm 10.34.5 V6 application and pnpm 9.15.9 documentation site so WSL release
   checks do not depend on a Windows Git or global package-manager setting.
+- Made feature-freeze release readiness install the repository-pinned Playwright
+  Chromium and operating-system dependencies before executing V6 browser evidence,
+  so clean GitHub runners no longer fail before E2E execution begins.
 
 ## [v1.1.0] - 2026-08-11
 

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -74,6 +74,19 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             frontend_install,
             "corepack pnpm@10.34.5 --dir web/antd-v6 install --frozen-lockfile --ignore-scripts",
         )
+        playwright_install = self.step("Install Playwright Chromium")
+        self.assertEqual(
+            playwright_install["if"], "${{ inputs.phase == 'feature-freeze' }}"
+        )
+        self.assertEqual(playwright_install["working-directory"], "web/antd-v6")
+        self.assertEqual(
+            playwright_install["run"],
+            "corepack pnpm@10.34.5 exec playwright install --with-deps chromium",
+        )
+        self.assertLess(
+            self.steps.index(playwright_install),
+            self.steps.index(phase),
+        )
         self.assertEqual(self.step("Setup pnpm")["with"]["version"], "9.15.9")
 
     def test_v120_qualification_carries_every_other_feature_forward(self):


### PR DESCRIPTION
## What changed

- install the repository-pinned Playwright Chromium and OS dependencies before feature-freeze command evidence runs
- add a workflow regression assertion that keeps the install feature-freeze-only and orders it before the phase runner
- document the runner setup correction in the Unreleased changelog

## Root cause

Release Readiness run 32104042342 reached the exact-SHA feature-freeze phase, where all non-browser commands passed. All 18 desktop/mobile E2E cases then failed before test execution because the clean GitHub runner had no Playwright Chromium executable at `/home/runner/.cache/ms-playwright/chromium_headless_shell-1234/...`.

The Frontend v6 CI and release workflows already install Chromium; the Release Readiness workflow omitted the equivalent deterministic setup.

## Tests and validation

- `python3 tools/release/test_release_readiness_workflow.py` (5 passed)
- `python3 -m unittest discover -s tools/release -p 'test_*.py'` (67 passed)
- `go run ./cmd/mss verify --changed` (success)
- `corepack pnpm@10.34.5 --dir web/antd-v6 exec playwright --version` (1.62.1)
- `git diff --check`

## Documentation impact

`CHANGELOG.md` now records that feature-freeze installs the pinned Chromium and operating-system dependencies on clean GitHub runners. No user-facing setup guide changes are required.

## Security impact

No authentication, authorization, secret handling, token permissions, or runtime security behavior changes. Installing the project-pinned browser makes the existing security and permission E2E suite executable in the clean readiness runner.

## Release, compatibility, migration, and rollback impact

The failed SHA remains unpublished and all v1.2.0 qualification evidence will be rerun after merge. There is no schema migration and no product compatibility change. Rollback is reverting this workflow-only commit before publication; no released artifact or tag exists to roll back.