### PR TITLE
fix(release): bind rc qualification feature

### DIFF
--- a/.github/workflows/agent-native-ci.yml
+++ b/.github/workflows/agent-native-ci.yml
@@ -238,6 +238,10 @@ jobs:
             tools/ci/test_detect_component_scope.py \
             tools/release/test_check_release_policy.py \
             tools/release/test_generate_admin_web_sbom.py \
+            tools/release/test_release_phase_evidence.py \
+            tools/release/test_release_qualification_decision.py \
+            tools/release/test_release_readiness_attestation.py \
+            tools/release/test_release_readiness_workflow.py \
             tools/release/test_verify_admin_web_package.py \
             tools/release/test_verify_release_source.py \
             tools/release/test_workflow_governance.py

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -198,6 +198,11 @@ spec:
       description: Build and validate the independently releasable Ant Design 6 frontend.
       category: frontend
 
+    frontend-v6-qualify:
+      command: make web-v6-qualify
+      description: Run the ordered V6 lint, unit test, release build, delivery smoke, and browser qualification sequence.
+      category: release
+
     docs-install:
       command: make docs-install
       description: Install documentation dependencies with the frozen lockfile.

--- a/.mss/features/complete-admin-distribution-thin-host.yaml
+++ b/.mss/features/complete-admin-distribution-thin-host.yaml
@@ -191,7 +191,9 @@ spec:
       required: true
       evidence:
         - type: command
-          value: make test-all and complete V6 lint, test, release build, delivery smoke, and browser regression
+          value: make test-all
+        - type: command
+          value: make web-v6-qualify
     - id: importable-backend-gate
       requirement: expose-importable-admin
       statement: The official Admin and a repository-external host compile and execute the same context-aware complete application entrypoint.
@@ -200,11 +202,13 @@ spec:
       required: true
       evidence:
         - type: command
-          value: cd admin && go test ./... && go vet ./...
+          value: cd admin && go test ./...
+        - type: command
+          value: cd admin && go vet ./...
         - type: command
           value: bash tools/compatibility/test-admin-external-consumer.sh
         - type: command
-          value: External thin-host GOWORK=off tidy, test, vet, build, and help verification
+          value: bash tools/compatibility/test-thin-host-external-consumer.sh
     - id: business-module-gate
       requirement: register-business-modules
       statement: Supplier uses the public module contract and duplicate, migration, readiness, authorization, and route-order cases pass.
@@ -222,7 +226,7 @@ spec:
       required: true
       evidence:
         - type: command
-          value: corepack pnpm@10.34.5 pack and external thin-host install, lint, test, and build
+          value: bash tools/compatibility/test-thin-host-external-consumer.sh
         - type: report
           value: Package file allowlist, dependency tree, runtime graph, and one-dist report
     - id: thin-host-blueprint-gate
@@ -252,6 +256,8 @@ spec:
       phase: feature-freeze
       required: true
       evidence:
+        - type: command
+          value: bash tools/compatibility/test-thin-host-external-consumer.sh
         - type: report
           value: External thin-host Playwright result and sanitized browser evidence
     - id: release-contract-gate

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ COVERAGE_POLICY := .mss/coverage.json
 	test-framework test-framework-race coverage-framework vet-framework \
 	tidy-framework-check verify-framework test-all generate lint fix-lint clean \
 	web-install web-lint web-test web-build \
-	web-v6-install web-v6-lint web-v6-test web-v6-build \
+	web-v6-install web-v6-lint web-v6-test web-v6-build web-v6-qualify \
 	docs-install docs-build verify-all
 
 build: build-admin
@@ -121,6 +121,13 @@ web-v6-test:
 
 web-v6-build:
 	cd web/antd-v6 && corepack pnpm@10.34.5 build:release
+
+web-v6-qualify:
+	$(MAKE) web-v6-lint
+	$(MAKE) web-v6-test
+	$(MAKE) web-v6-build
+	cd web/antd-v6 && corepack pnpm@10.34.5 delivery:smoke
+	cd web/antd-v6 && corepack pnpm@10.34.5 test:e2e
 
 docs-install:
 	cd docs && corepack pnpm@9.15.9 install --frozen-lockfile

--- a/docs/docs/operations/admin-distribution-v1.3.0-rc.1.zh-CN.md
+++ b/docs/docs/operations/admin-distribution-v1.3.0-rc.1.zh-CN.md
@@ -90,3 +90,8 @@ go run ./cmd/mss new app preview-admin \
 包可安装、前后端测试和构建通过、Supplier 业务模块可用，并在仓库外 Thin Host
 上完成登录、菜单、CRUD、拒绝访问、刷新与控制台健康检查。测试项目应保留，供
 人工检查；预览版发现问题后发布新的 RC，不移动或覆盖既有标签和包版本。
+
+发布资格决策必须只绑定 `.mss/release-qualification.json` 选中的
+`complete-admin-distribution-thin-host` Feature。Agent CI 会在每个相关 PR 中运行阶段证据、
+资格决策、readiness attestation 与工作流合同测试；活动版本、Feature 或精确提交绑定发生漂移时，
+预发布流程必须在创建任何标签或制品前失败。

--- a/tools/release/release_phase_evidence.py
+++ b/tools/release/release_phase_evidence.py
@@ -28,6 +28,13 @@ FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 SAFE_ID_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
 ENVIRONMENT_NAME_RE = re.compile(r"^(?:GOWORK|GOTOOLCHAIN|GOFLAGS|MSS_[A-Z0-9_]+)$")
 ALLOWED_EXECUTABLES = frozenset(("bash", "corepack", "go", "make", "node", "pnpm", "python3"))
+ALLOWED_BASH_SCRIPTS = frozenset(
+    (
+        "tools/compatibility/test-admin-external-consumer.sh",
+        "tools/compatibility/test-thin-host-external-consumer.sh",
+        "tools/release/verify_readiness_run.sh",
+    )
+)
 SHELL_CONTROL_TOKENS = frozenset(("&&", "||", ";", "|", ">", ">>", "<", "<<"))
 
 
@@ -239,8 +246,10 @@ def parse_command(value: str) -> ParsedCommand:
     if any("$(" in token or "`" in token for token in argv):
         raise PhaseEvidenceError("shell expansion is not allowed in command evidence")
     if argv[0] == "bash":
-        if len(argv) < 2 or argv[1].startswith("-") or not argv[1].startswith("tools/release/"):
-            raise PhaseEvidenceError("bash evidence may invoke only a checked-in tools/release script")
+        if len(argv) < 2 or argv[1] not in ALLOWED_BASH_SCRIPTS:
+            raise PhaseEvidenceError(
+                "bash evidence may invoke only an explicitly allowlisted qualification script"
+            )
     return ParsedCommand(argv, working_directory, environment)
 
 

--- a/tools/release/release_qualification_decision.py
+++ b/tools/release/release_qualification_decision.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 SCHEMA = "mss.io/release-qualification-decision/v1"
 QUALIFICATION_SCHEMA = "mss.io/release-qualification/v1"
-RELEASE_FEATURE = ".mss/features/foundation-v1-2-3-release.yaml"
+RELEASE_FEATURE = ".mss/features/complete-admin-distribution-thin-host.yaml"
 FULL_COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
 PLACEHOLDER_RE = re.compile(r"^(?:none|null|n/a|na|pending|todo|tbd|<.*>)$", re.IGNORECASE)
 

--- a/tools/release/test_release_phase_evidence.py
+++ b/tools/release/test_release_phase_evidence.py
@@ -142,6 +142,27 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
             EVIDENCE.parse_command("bash tools/release/verify_readiness_run.sh --help").argv[:2],
             ["bash", "tools/release/verify_readiness_run.sh"],
         )
+        for script in (
+            "tools/compatibility/test-admin-external-consumer.sh",
+            "tools/compatibility/test-thin-host-external-consumer.sh",
+        ):
+            with self.subTest(script=script):
+                self.assertEqual(
+                    EVIDENCE.parse_command(f"bash {script}").argv,
+                    ["bash", script],
+                )
+
+    def test_rejects_nonqualification_bash_scripts(self):
+        for script in (
+            "tools/compatibility/process-groups.sh",
+            "tools/release/../compatibility/test-admin-external-consumer.sh",
+            "scripts/arbitrary.sh",
+        ):
+            with self.subTest(script=script):
+                with self.assertRaisesRegex(
+                    EVIDENCE.PhaseEvidenceError, "explicitly allowlisted"
+                ):
+                    EVIDENCE.parse_command(f"bash {script}")
 
     def test_parses_safe_repository_cwd_and_allowlisted_environment_without_shell(self):
         command = EVIDENCE.parse_command(

--- a/tools/release/test_release_qualification_decision.py
+++ b/tools/release/test_release_qualification_decision.py
@@ -8,8 +8,12 @@ from pathlib import Path
 
 
 TOOLS_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = TOOLS_DIR.parents[1]
 sys.path.insert(0, str(TOOLS_DIR))
 import release_qualification_decision as DECISION  # noqa: E402
+
+
+TARGET_VERSION = "v1.3.0-rc.1"
 
 
 class ReleaseQualificationDecisionTest(unittest.TestCase):
@@ -22,7 +26,7 @@ class ReleaseQualificationDecisionTest(unittest.TestCase):
             json.dumps(
                 {
                     "schema": "mss.io/release-qualification/v1",
-                    "targetVersion": "v1.2.3",
+                    "targetVersion": TARGET_VERSION,
                     "features": [DECISION.RELEASE_FEATURE],
                     "excludedFeatures": [
                         {
@@ -45,7 +49,7 @@ class ReleaseQualificationDecisionTest(unittest.TestCase):
     def build(self, root, commit, **overrides):
         values = {
             "qualification": ".mss/release-qualification.json",
-            "target_version": "v1.2.3",
+            "target_version": TARGET_VERSION,
             "commit": commit,
             "phase": "feature-freeze",
             "browser_commit": commit,
@@ -70,6 +74,12 @@ class ReleaseQualificationDecisionTest(unittest.TestCase):
         )
         self.assertFalse(decision["scope"]["objectStoreProviderConformanceRequired"])
         self.assertFalse(decision["scope"]["rustfsRequired"])
+
+    def test_repository_qualification_matches_active_release_binding(self):
+        contract = REPOSITORY_ROOT / ".mss" / "release-qualification.json"
+        value, digest = DECISION._load_qualification(contract, TARGET_VERSION)
+        self.assertEqual(value["features"], [DECISION.RELEASE_FEATURE])
+        self.assertEqual(digest, hashlib.sha256(contract.read_bytes()).hexdigest())
 
     def test_rejects_short_or_mismatched_evidence_commits(self):
         temporary, root, _, commit = self.fixture()

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -112,6 +112,45 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             )
         )
 
+    def test_v130_rc1_feature_freeze_commands_are_exact_and_executable(self):
+        feature_path = (
+            REPOSITORY_ROOT
+            / ".mss"
+            / "features"
+            / "complete-admin-distribution-thin-host.yaml"
+        )
+        feature = yaml.safe_load(feature_path.read_text(encoding="utf-8"))
+        plan = {
+            "feature": {"name": feature["metadata"]["name"]},
+            "acceptance": feature["spec"]["acceptance"],
+        }
+        steps, review = PHASE_EVIDENCE.collect_phase_commands(
+            [plan], phase="feature-freeze"
+        )
+        blockers = [
+            item
+            for item in review
+            if item.get("type") in {"non-exact-command", "unsupported-command"}
+        ]
+        self.assertEqual(blockers, [])
+        commands = {
+            " ".join(
+                [
+                    step.working_directory,
+                    *(f"{name}={value}" for name, value in sorted(step.environment.items())),
+                    *step.argv,
+                ]
+            )
+            for step in steps
+        }
+        for required in (
+            ". make test-all",
+            ". make web-v6-qualify",
+            ". bash tools/compatibility/test-admin-external-consumer.sh",
+            ". bash tools/compatibility/test-thin-host-external-consumer.sh",
+        ):
+            self.assertIn(required, commands)
+
     def test_historical_v123_release_feature_has_scoped_exact_commands(self):
         feature = yaml.safe_load(FEATURE_PATH.read_text(encoding="utf-8"))
         plan = {

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -111,6 +111,10 @@ class WorkflowGovernanceTest(unittest.TestCase):
         )
         self.assertIn("test_detect_component_scope.py", governance["run"])
         self.assertIn("test_check_release_policy.py", governance["run"])
+        self.assertIn("test_release_phase_evidence.py", governance["run"])
+        self.assertIn("test_release_qualification_decision.py", governance["run"])
+        self.assertIn("test_release_readiness_attestation.py", governance["run"])
+        self.assertIn("test_release_readiness_workflow.py", governance["run"])
         self.assertIn("test_verify_release_source.py", governance["run"])
         self.assertIn("test_workflow_governance.py", governance["run"])
 


### PR DESCRIPTION
## Summary

- bind the manual release qualification decision to the active complete Admin Distribution Feature for v1.3.0-rc.1
- replace stale natural-language evidence with six exact executable feature-freeze commands
- add an ordered `make web-v6-qualify` gate for lint, unit tests, release build, delivery smoke, and browser E2E
- explicitly allow only the two external-consumer qualification scripts and the readiness verifier at the Bash boundary
- run phase evidence, qualification decision, attestation, and workflow contract tests in regular Agent CI

## Validation

- `python3 -m unittest discover -s tools/release -p 'test_*.py'` (107 passed)
- active Feature planner: 6 commands, 0 unsupported or non-exact blockers
- `go run ./cmd/mss spec validate .mss/features/complete-admin-distribution-thin-host.yaml --format json`
- `make -n web-v6-qualify`
- workflow YAML parse passed
- `corepack pnpm@9.15.9 --dir docs build`
- `go run ./cmd/mss verify --changed --base origin/main`
- `git diff --check`

## Documentation impact

The v1.3.0-rc.1 preview operations guide documents the exact qualification Feature binding and the CI suites that prevent version, Feature, command, or commit drift.

## Release impact

This repairs two pre-publication blockers: the historical v1.2.3 Feature binding and non-executable feature-freeze command evidence. No release workflow, tag, package, image, or GitHub Release has been started. After merge, qualification restarts from the new exact merged-main commit.

## Security impact

No credentials, runtime permissions, or publication authority are expanded. Bash evidence is now restricted to three exact checked-in qualification scripts, and release-contract drift fails closed in pull-request CI.