### PR TITLE
fix(release): preflight prerelease npm publication

### DIFF
--- a/.github/workflows/frontend-v6-release.yml
+++ b/.github/workflows/frontend-v6-release.yml
@@ -48,10 +48,15 @@ jobs:
           resolved_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
           test "${resolved_commit}" = "${GITHUB_SHA}"
           prerelease=false
-          if [[ "${version}" == *-* ]]; then prerelease=true; fi
+          npm_dist_tag=latest
+          if [[ "${version}" == *-* ]]; then
+            prerelease=true
+            npm_dist_tag=next
+          fi
           {
             echo "version=${version}"
             echo "prerelease=${prerelease}"
+            echo "npm_dist_tag=${npm_dist_tag}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Verify merged-main release source
@@ -287,6 +292,25 @@ jobs:
           echo 'publish=true' >> "${GITHUB_OUTPUT}"
           rm -f "${error_file}"
 
+      - name: Preflight immutable Admin Web publication without mutation
+        if: steps.npm-version.outputs.publish == 'true'
+        env:
+          NPM_DIST_TAG: ${{ steps.version.outputs.npm_dist_tag }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          case "${NPM_DIST_TAG}" in
+            latest|next) ;;
+            *) echo "unsupported npm dist-tag: ${NPM_DIST_TAG}" >&2; exit 1 ;;
+          esac
+          mapfile -t tarballs < <(find "${RUNNER_TEMP}/admin-web-release-package" \
+            -maxdepth 1 -type f -name '*.tgz' -print)
+          test "${#tarballs[@]}" -eq 1
+          npm publish "${tarballs[0]}" \
+            --dry-run \
+            --tag "${NPM_DIST_TAG}" \
+            --registry=https://npm.pkg.github.com
+
       - name: Attest Admin Web package provenance
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
         with:
@@ -481,18 +505,25 @@ jobs:
       - name: Publish immutable Admin Web package to GitHub Packages
         if: steps.npm-version.outputs.publish == 'true'
         env:
+          NPM_DIST_TAG: ${{ steps.version.outputs.npm_dist_tag }}
           NODE_AUTH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          case "${NPM_DIST_TAG}" in
+            latest|next) ;;
+            *) echo "unsupported npm dist-tag: ${NPM_DIST_TAG}" >&2; exit 1 ;;
+          esac
           mapfile -t tarballs < <(find "${RUNNER_TEMP}/admin-web-release-package" \
             -maxdepth 1 -type f -name '*.tgz' -print)
           test "${#tarballs[@]}" -eq 1
           npm publish "${tarballs[0]}" \
+            --tag "${NPM_DIST_TAG}" \
             --registry=https://npm.pkg.github.com
 
       - name: Verify GitHub Packages identity and repository binding
         env:
           ADMIN_WEB_VERSION: ${{ steps.version.outputs.version }}
+          NPM_DIST_TAG: ${{ steps.version.outputs.npm_dist_tag }}
           GH_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{ github.token }}
         run: |
@@ -514,6 +545,15 @@ jobs:
             '.version == $version and .gitHead == $commit and
              ."dist.integrity" == $integrity' \
             <<< "${package_metadata}" >/dev/null
+          dist_tags="$(
+            npm view '@mss-boot-io/admin-web' dist-tags --json \
+              --registry=https://npm.pkg.github.com
+          )"
+          jq -e \
+            --arg tag "${NPM_DIST_TAG}" \
+            --arg version "${unprefixed_version}" \
+            '.[$tag] == $version' \
+            <<< "${dist_tags}" >/dev/null
           package_record="$(
             gh api "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/npm/admin-web"
           )"

--- a/.mss/blueprints/management-system.yaml
+++ b/.mss/blueprints/management-system.yaml
@@ -11,13 +11,13 @@ spec:
   sourceProjectName: mss-boot-admin
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.2
+    version: v1.3.0-rc.3
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.2
+      version: v1.3.0-rc.3
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.2
+      version: 1.3.0-rc.3
   defaultOutputDirectory: .mss/output
   manifestPath: .mss/blueprint-manifest.json
   lockPath: .mss/lock.yaml

--- a/.mss/capabilities.yaml
+++ b/.mss/capabilities.yaml
@@ -877,9 +877,9 @@ spec:
       guidance: >-
         Treat Unreleased, planned, preview, branches, and local workspace replacements as non-stable.
         Published historical versions remain immutable and their candidate evidence is not reusable.
-        The active reviewed target is the v1.3.0-rc.2 preview for root, Framework, the importable Admin module,
+        The active reviewed target is the v1.3.0-rc.3 preview for root, Framework, the importable Admin module,
         and the sole Ant Design V6 frontend. Other alpha, beta, RC, or stable tags remain forbidden.
-        Complete release readiness begins only after one v1.3.0-rc.2 feature-freeze commit already
+        Complete release readiness begins only after one v1.3.0-rc.3 feature-freeze commit already
         merged into main is selected. An emergency
         patch requires a reviewed policy target change rather than a bypass.
         Publish Framework first, then the importable Admin module, then the complete frontend package,

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -239,40 +239,40 @@ spec:
       idempotent: true
 
     release-phase-evidence-plan:
-      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.2 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
-      description: Resolve the explicitly selected v1.3.0-rc.2 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
+      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
+      description: Resolve the explicitly selected v1.3.0-rc.3 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-phase-evidence-run:
-      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.2 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
+      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.3 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
       description: On one clean frozen commit, execute the scoped release Feature commands without a shell, retain per-command digests and logs, and fail when a selected command fails, times out, or still uses non-exact named Go test evidence.
       outputFormats: [json]
       category: release
 
     release-qualification-decision:
-      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.2 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
+      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.3 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
       description: Bind the Codex in-app Browser and external Blueprint rehearsal evidence to the exact frozen SHA while recording carry-forward and optional ObjectStore/RustFS decisions.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-readiness-attestation-create:
-      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.2 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
+      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
       description: Create the strict readiness metadata for one exact workflow run; the checked-in development policy permits checkpoint qualification only and cannot grant publication authority.
       outputFormats: [text]
       category: release
 
     release-readiness-attestation-verify:
-      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.2 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
+      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
       description: Reject an attestation unless its exact schema, version, commit, phase, policy digest, selected run identity, URL, and authority match the requested intent.
       outputFormats: [text]
       category: release
       idempotent: true
 
     release-readiness-run-verify:
-      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.2 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
+      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.3 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
       description: Read the specifically selected successful release-readiness workflow run and its run-named artifact, then require an exact publication attestation before a publishing workflow writes externally.
       outputFormats: [text]
       category: release

--- a/.mss/features/complete-admin-distribution-thin-host.yaml
+++ b/.mss/features/complete-admin-distribution-thin-host.yaml
@@ -11,7 +11,7 @@ metadata:
     domain: admin-distribution
     implementation-status: complete
     release-status: rc-qualification
-    target-version: v1.3.0-rc.2
+    target-version: v1.3.0-rc.3
     compatibility: coordinated-backend-frontend-version
     privacy: no-telemetry
 spec:
@@ -156,11 +156,16 @@ spec:
         - The nested Admin Go module uses admin/vX.Y.Z and all coordinated artifacts share the same exact semantic version, including prerelease identifiers.
         - Frontend qualification includes pack contents, integrity, SBOM, GitHub provenance attestation, and fail-closed credential handling.
         - Admin Web publishes first to GitHub Packages under the repository-linked @mss-boot-io scope; Thin Hosts authenticate without committing a token.
-        - The v1.3.0-rc.2 train is a prerelease and does not replace the current v1.2.3 stable release.
+        - The v1.3.0-rc.3 train is a prerelease and does not replace the current v1.2.3 stable release.
         - >-
           The immutable v1.3.0-rc.1 train remains partial evidence: Framework, Admin, and the
           frontend image published, while the frontend package, frontend GitHub Release, and root
           release did not publish after multi-architecture verification failed.
+        - >-
+          The immutable v1.3.0-rc.2 train remains partial evidence: Framework, Admin, and the
+          corrected multi-architecture frontend image published, while the frontend package,
+          frontend GitHub Release, and root release did not publish because npm requires an
+          explicit dist-tag when publishing a prerelease version.
     - id: preserve-privacy-boundary
       title: Preserve the no-telemetry boundary
       description: Creation, installation, execution, verification, and upgrade remain local and collect no adopter data.

--- a/.mss/lock.yaml
+++ b/.mss/lock.yaml
@@ -5,13 +5,13 @@ metadata:
 spec:
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.2
+    version: v1.3.0-rc.3
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.2
+      version: v1.3.0-rc.3
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.2
+      version: 1.3.0-rc.3
   foundation:
     repository: mss-boot-io/mss-boot-admin
     version: 0.1.0

--- a/.mss/project.yaml
+++ b/.mss/project.yaml
@@ -11,13 +11,13 @@ spec:
   foundationVersion: 0.1.0
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.2
+    version: v1.3.0-rc.3
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.2
+      version: v1.3.0-rc.3
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.2
+      version: 1.3.0-rc.3
   repositoryLayout:
     kind: foundation
     backend: admin

--- a/.mss/release-policy.yaml
+++ b/.mss/release-policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: mss.io/v1alpha1
 kind: ReleasePolicy
 metadata:
-  name: foundation-v1-3-0-rc-2-release
+  name: foundation-v1-3-0-rc-3-release
 spec:
   mode: development-first
   releaseBranch: main
   requireMergedPullRequestSource: true
   currentStableVersion: v1.2.3
   currentStableCommit: 260d546851c58f7293b30e76b47d40d8e89f52fe
-  nextPublicVersion: v1.3.0-rc.2
-  distributionVersion: v1.3.0-rc.2
+  nextPublicVersion: v1.3.0-rc.3
+  distributionVersion: v1.3.0-rc.3
   distributionComponents: "root,framework,admin,frontend"
   publicationWorkflowsReady: true
   publicPrereleases: true

--- a/.mss/release-qualification.json
+++ b/.mss/release-qualification.json
@@ -1,6 +1,6 @@
 {
   "schema": "mss.io/release-qualification/v1",
-  "targetVersion": "v1.3.0-rc.2",
+  "targetVersion": "v1.3.0-rc.3",
   "features": [
     ".mss/features/complete-admin-distribution-thin-host.yaml"
   ],

--- a/admin/go.mod
+++ b/admin/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/pyroscope-go v1.4.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.10
-	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.2
+	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.3
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
+++ b/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
@@ -1,6 +1,6 @@
 # ADR: Complete Admin distribution and thin business hosts
 
-- Status: Accepted; v1.3.0-rc.2 preview qualification in progress
+- Status: Accepted; v1.3.0-rc.3 preview qualification in progress
 - Date: 2026-08-19
 - Owners: Admin, frontend, agent infrastructure, release engineering
 - Feature contract: `.mss/features/complete-admin-distribution-thin-host.yaml`
@@ -89,7 +89,7 @@ business files, and records a thin baseline only after all file operations and v
 
 Technical artifacts may use root, `mss-boot/`, `admin/`, and `web/antd-v6/` tag namespaces, but their
 exact semantic version, including a prerelease suffix, must match for a coordinated distribution. The
-current public consumption rehearsal uses `v1.3.0-rc.2`; it is marked as a prerelease and does not replace
+current public consumption rehearsal uses `v1.3.0-rc.3`; it is marked as a prerelease and does not replace
 the current `v1.2.3` stable release. Publication remains restricted to the exact merged-main commit and
 the protected Framework -> Admin -> Frontend -> Root release train.
 
@@ -97,6 +97,11 @@ The immutable `v1.3.0-rc.1` train remains partial evidence. Framework, Admin, an
 frontend image published, but a workflow verifier defect stopped the frontend package and GitHub Release;
 the root tag and Release were never created. The repair advances the coordinated version instead of moving
 or reusing any published tag or artifact.
+
+The immutable `v1.3.0-rc.2` train also remains partial evidence. Framework, Admin, and the corrected
+multi-architecture frontend image published and passed identity checks, but npm rejected the prerelease
+package because the publish command omitted an explicit dist-tag. The repair assigns `next` to prereleases
+and `latest` to stable releases, adds a distribution-tag assertion, and advances the coordinated version.
 
 Before publication, rollback is a normal revert of the feature commits. After downstream adoption,
 rollback pins the previous Admin Distribution and restores the previous thin-host lock and manifest.

--- a/docs/docs/operations/admin-distribution-v1.3.0-rc.3.zh-CN.md
+++ b/docs/docs/operations/admin-distribution-v1.3.0-rc.3.zh-CN.md
@@ -1,11 +1,11 @@
 ---
-title: Admin Distribution v1.3.0-rc.2 预览版引用
+title: Admin Distribution v1.3.0-rc.3 预览版引用
 order: 35
 ---
 
-# Admin Distribution v1.3.0-rc.2 预览版引用
+# Admin Distribution v1.3.0-rc.3 预览版引用
 
-`v1.3.0-rc.2` 是完整 Admin Distribution 的公开预览版，不替代当前
+`v1.3.0-rc.3` 是完整 Admin Distribution 的公开预览版，不替代当前
 `v1.2.3` 稳定版。Root、Framework、Admin Go Module 与 Admin Web 使用同一个
 精确版本，并从同一个已合并到 `main` 的提交发布。
 
@@ -13,11 +13,11 @@ order: 35
 
 | 组件 | 引用 |
 | --- | --- |
-| Root | `v1.3.0-rc.2` |
-| Framework | `mss-boot/v1.3.0-rc.2` |
-| Admin Go Module | `admin/v1.3.0-rc.2` |
-| Admin Web | GitHub Packages：`@mss-boot-io/admin-web@1.3.0-rc.2` |
-| 前端镜像 | `ghcr.io/mss-boot-io/mss-boot-admin-antd-v6:v1.3.0-rc.2` |
+| Root | `v1.3.0-rc.3` |
+| Framework | `mss-boot/v1.3.0-rc.3` |
+| Admin Go Module | `admin/v1.3.0-rc.3` |
+| Admin Web | GitHub Packages：`@mss-boot-io/admin-web@1.3.0-rc.3` |
+| 前端镜像 | `ghcr.io/mss-boot-io/mss-boot-admin-antd-v6:v1.3.0-rc.3` |
 
 ## rc.1 状态
 
@@ -26,14 +26,21 @@ order: 35
 manifest-list digest 依次校验 amd64 与 arm64，第二次创建容器时被 Docker 拒绝。
 修复通过新的 Pull Request 合并，并推进到 `rc.2`；不会移动、覆盖或复用任何 `rc.1` 标签和制品。
 
+## rc.2 状态
+
+`v1.3.0-rc.2` 同样保留为不可变的部分发布记录：Framework、Admin 以及修复后的多架构前端镜像已经发布；
+Admin Web 包、前端 GitHub Release 与 Root Release 未发布。镜像身份和双架构容器验证均已通过，随后 npm 拒绝发布预发布
+版本，因为命令没有显式指定 dist-tag。修复通过新的 Pull Request 合并，预发布版本固定使用 `next`、正式版本固定使用
+`latest`，并推进到 `rc.3`；不会移动、覆盖或复用任何 `rc.2` 标签和制品。
+
 ## 后端引用
 
 Thin Host 的 `go.mod` 必须同时精确固定 Admin 与 Framework：
 
 ```go
 require (
-    github.com/mss-boot-io/mss-boot-admin/admin v1.3.0-rc.2
-    github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.2
+    github.com/mss-boot-io/mss-boot-admin/admin v1.3.0-rc.3
+    github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.3
 )
 ```
 

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -26,20 +26,20 @@ class ReleasePolicyTest(unittest.TestCase):
 
     def test_v130_rc2_matches_every_distribution_component_namespace(self):
         cases = {
-            "root": "v1.3.0-rc.2",
-            "framework": "mss-boot/v1.3.0-rc.2",
-            "admin": "admin/v1.3.0-rc.2",
-            "frontend": "web/antd-v6/v1.3.0-rc.2",
-            "docs": "docs/v1.3.0-rc.2",
+            "root": "v1.3.0-rc.3",
+            "framework": "mss-boot/v1.3.0-rc.3",
+            "admin": "admin/v1.3.0-rc.3",
+            "frontend": "web/antd-v6/v1.3.0-rc.3",
+            "docs": "docs/v1.3.0-rc.3",
         }
         for component, tag in cases.items():
             with self.subTest(component=component):
                 POLICY.check_public_ref(
-                    self.policy, component, "v1.3.0-rc.2", tag, intent="qualify"
+                    self.policy, component, "v1.3.0-rc.3", tag, intent="qualify"
                 )
 
         self.assertEqual(
-            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.2"),
+            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.3"),
             {component: cases[component] for component in POLICY.COORDINATED_COMPONENTS},
         )
 
@@ -47,7 +47,7 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertIs(self.policy["publicationWorkflowsReady"], True)
         self.assertIs(self.policy["publicPrereleases"], True)
         POLICY.check_public_ref(
-            self.policy, "root", "v1.3.0-rc.2", "v1.3.0-rc.2"
+            self.policy, "root", "v1.3.0-rc.3", "v1.3.0-rc.3"
         )
 
     def test_policy_requires_pr_merged_main_release_source(self):
@@ -84,15 +84,15 @@ class ReleasePolicyTest(unittest.TestCase):
             POLICY.check_public_ref(
                 self.policy,
                 "framework",
-                "v1.3.0-rc.2",
-                "v1.3.0-rc.2",
+                "v1.3.0-rc.3",
+                "v1.3.0-rc.3",
                 intent="qualify",
             )
 
     def test_policy_rejects_distribution_version_or_component_drift(self):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
-            ("  distributionVersion: v1.3.0-rc.2\n", "  distributionVersion: v1.3.1\n"),
+            ("  distributionVersion: v1.3.0-rc.3\n", "  distributionVersion: v1.3.1\n"),
             (
                 '  distributionComponents: "root,framework,admin,frontend"\n',
                 '  distributionComponents: "root,framework,frontend"\n',
@@ -110,7 +110,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
             ("  publicPrereleases: true\n", "  publicPrereleases: false\n"),
-            ("  nextPublicVersion: v1.3.0-rc.2\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
+            ("  nextPublicVersion: v1.3.0-rc.3\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
             ("  currentStableVersion: v1.2.3\n", "  currentStableVersion: v1.2.3-rc.1\n"),
         )
         for old, new in replacements:
@@ -120,7 +120,7 @@ class ReleasePolicyTest(unittest.TestCase):
                     content = original.replace(old, new)
                     if "nextPublicVersion" in new:
                         content = content.replace(
-                            "  distributionVersion: v1.3.0-rc.2\n",
+                            "  distributionVersion: v1.3.0-rc.3\n",
                             "  distributionVersion: v1.3.0-rc.01\n",
                         )
                     candidate.write_text(content, encoding="utf-8")
@@ -131,7 +131,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         for suffix in (
             "  unexpected: true\n",
-            "  nextPublicVersion: v1.3.0-rc.2\n",
+            "  nextPublicVersion: v1.3.0-rc.3\n",
         ):
             with self.subTest(suffix=suffix.strip()):
                 with tempfile.TemporaryDirectory() as directory:

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -54,7 +54,7 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertEqual(self.policy["releaseBranch"], "main")
         self.assertIs(self.policy["requireMergedPullRequestSource"], True)
 
-    def test_policy_rejects_versions_other_than_v130_rc2(self):
+    def test_policy_rejects_versions_other_than_v130_rc3(self):
         for version in (
             "v1.0.1",
             "v1.1.0",

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -24,7 +24,7 @@ class ReleasePolicyTest(unittest.TestCase):
     def setUp(self):
         self.policy = POLICY.load_policy(POLICY_PATH)
 
-    def test_v130_rc2_matches_every_distribution_component_namespace(self):
+    def test_v130_rc3_matches_every_distribution_component_namespace(self):
         cases = {
             "root": "v1.3.0-rc.3",
             "framework": "mss-boot/v1.3.0-rc.3",

--- a/tools/release/test_release_phase_evidence.py
+++ b/tools/release/test_release_phase_evidence.py
@@ -214,7 +214,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
             EVIDENCE.validate_binding(
                 root,
                 policy_path=policy,
-                target_version="v1.3.0-rc.2",
+                target_version="v1.3.0-rc.3",
                 commit=commit,
                 require_clean=True,
             )
@@ -223,7 +223,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
                 EVIDENCE.validate_binding(
                     root,
                     policy_path=policy,
-                    target_version="v1.3.0-rc.2",
+                    target_version="v1.3.0-rc.3",
                     commit=commit,
                     require_clean=True,
                 )

--- a/tools/release/test_release_qualification_decision.py
+++ b/tools/release/test_release_qualification_decision.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 import release_qualification_decision as DECISION  # noqa: E402
 
 
-TARGET_VERSION = "v1.3.0-rc.2"
+TARGET_VERSION = "v1.3.0-rc.3"
 
 
 class ReleaseQualificationDecisionTest(unittest.TestCase):

--- a/tools/release/test_release_readiness_attestation.py
+++ b/tools/release/test_release_readiness_attestation.py
@@ -20,7 +20,7 @@ RUN_ID = 123456789
 RUN_URL = (
     "https://github.com/mss-boot-io/mss-boot-admin/actions/runs/123456789"
 )
-TARGET_VERSION = "v1.3.0-rc.2"
+TARGET_VERSION = "v1.3.0-rc.3"
 
 
 class ReleaseReadinessAttestationTest(unittest.TestCase):

--- a/tools/release/test_release_readiness_attestation.py
+++ b/tools/release/test_release_readiness_attestation.py
@@ -50,7 +50,7 @@ class ReleaseReadinessAttestationTest(unittest.TestCase):
     def ready_policy(self, directory: str) -> Path:
         return self.policy_with_readiness(directory, True)
 
-    def test_checkpoint_attestation_binds_exact_v130_rc2_metadata(self):
+    def test_checkpoint_attestation_binds_exact_v130_rc3_metadata(self):
         attestation = self.checkpoint()
         self.assertEqual(set(attestation), ATTESTATION.REQUIRED_KEYS)
         self.assertEqual(attestation["schema"], ATTESTATION.SCHEMA)

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -93,7 +93,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         selected = PHASE_EVIDENCE.load_qualification(
             REPOSITORY_ROOT,
             Path(".mss/release-qualification.json"),
-            "v1.3.0-rc.2",
+            "v1.3.0-rc.3",
         )
         self.assertEqual(
             [path.relative_to(REPOSITORY_ROOT).as_posix() for path in selected],

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -89,7 +89,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(self.step("Setup pnpm")["with"]["version"], "9.15.9")
 
-    def test_v130_rc2_qualification_selects_the_distribution_feature(self):
+    def test_v130_rc3_qualification_selects_the_distribution_feature(self):
         selected = PHASE_EVIDENCE.load_qualification(
             REPOSITORY_ROOT,
             Path(".mss/release-qualification.json"),
@@ -112,7 +112,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             )
         )
 
-    def test_v130_rc2_feature_freeze_commands_are_exact_and_executable(self):
+    def test_v130_rc3_feature_freeze_commands_are_exact_and_executable(self):
         feature_path = (
             REPOSITORY_ROOT
             / ".mss"

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -351,6 +351,14 @@ class WorkflowGovernanceTest(unittest.TestCase):
         for permission in ("attestations", "id-token"):
             self.assertEqual(release["permissions"][permission], "write")
         steps = release["steps"]
+        identity = next(
+            step
+            for step in steps
+            if step.get("name") == "Resolve immutable v6 release identity"
+        )["run"]
+        self.assertIn("npm_dist_tag=latest", identity)
+        self.assertIn("npm_dist_tag=next", identity)
+        self.assertIn('echo "npm_dist_tag=${npm_dist_tag}"', identity)
         admin_predecessor = next(
             step
             for step in steps
@@ -380,6 +388,24 @@ class WorkflowGovernanceTest(unittest.TestCase):
         self.assertIn("dist.integrity", credential["run"])
         self.assertIn("https://npm.pkg.github.com", credential["run"])
         self.assertIn("existing npm version has different immutable content", credential["run"])
+        preflight = next(
+            step
+            for step in steps
+            if step.get("name")
+            == "Preflight immutable Admin Web publication without mutation"
+        )
+        self.assertEqual(
+            preflight["if"], "steps.npm-version.outputs.publish == 'true'"
+        )
+        self.assertEqual(
+            preflight["env"]["NPM_DIST_TAG"],
+            "${{ steps.version.outputs.npm_dist_tag }}",
+        )
+        self.assertEqual(preflight["env"]["NODE_AUTH_TOKEN"], "${{ github.token }}")
+        self.assertIn("npm publish", preflight["run"])
+        self.assertIn("--dry-run", preflight["run"])
+        self.assertIn('--tag "${NPM_DIST_TAG}"', preflight["run"])
+        self.assertIn("https://npm.pkg.github.com", preflight["run"])
 
         attestation = next(
             step
@@ -396,11 +422,18 @@ class WorkflowGovernanceTest(unittest.TestCase):
             if step.get("name") == "Publish immutable Admin Web package to GitHub Packages"
         )
         self.assertIn("npm publish", publish["run"])
+        self.assertIn('--tag "${NPM_DIST_TAG}"', publish["run"])
         self.assertIn("https://npm.pkg.github.com", publish["run"])
+        self.assertIn("latest|next", publish["run"])
         self.assertEqual(
             publish["if"], "steps.npm-version.outputs.publish == 'true'"
         )
+        self.assertEqual(
+            publish["env"]["NPM_DIST_TAG"],
+            "${{ steps.version.outputs.npm_dist_tag }}",
+        )
         self.assertEqual(publish["env"]["NODE_AUTH_TOKEN"], "${{ github.token }}")
+        self.assertLess(steps.index(preflight), steps.index(publish))
         verify_package = next(
             step
             for step in steps
@@ -409,6 +442,12 @@ class WorkflowGovernanceTest(unittest.TestCase):
         )
         self.assertIn('.visibility == "private"', verify_package["run"])
         self.assertIn('.visibility == "public"', verify_package["run"])
+        self.assertIn("dist-tags", verify_package["run"])
+        self.assertIn('.[$tag] == $version', verify_package["run"])
+        self.assertEqual(
+            verify_package["env"]["NPM_DIST_TAG"],
+            "${{ steps.version.outputs.npm_dist_tag }}",
+        )
         self.assertIn("admin-web", verify_package["run"])
 
         image_state = next(
@@ -416,6 +455,7 @@ class WorkflowGovernanceTest(unittest.TestCase):
             for step in steps
             if step.get("name") == "Inspect immutable v6 image publication state"
         )
+        self.assertLess(steps.index(preflight), steps.index(image_state))
         self.assertIn("imagetools inspect", image_state["run"])
         self.assertIn("exists=true", image_state["run"])
         self.assertIn("authoritative not-found", image_state["run"])


### PR DESCRIPTION
## Outcome

- publish prerelease Admin Web packages with explicit next dist-tag and stable packages with latest
- run the exact npm publish command in dry-run mode before any immutable image is pushed
- verify the published dist-tag resolves to the exact package version
- advance the coordinated immutable preview train from partial rc.2 evidence to v1.3.0-rc.3
- preserve rc.1 and rc.2 failure histories without moving or reusing their tags

## Root cause

Frontend RC2 passed browser, build, package, SBOM, image build, and corrected multi-architecture image verification. npm then refused the prerelease package because npm publish omitted a required explicit tag.

## Tests and validation

- npm package publish dry-run against the GitHub registry with tag next
- release test suite: 107 passed
- focused Project, Blueprint, and App Go tests
- docs production build
- GOFLAGS=-mod=readonly go run ./cmd/mss verify --changed
- workflow YAML parse and irreversible-step ordering assertion

## Documentation impact

The active preview guide and ADR advance to rc.3 and preserve immutable rc.1 and rc.2 partial-release evidence.

## Security impact

The dist-tag is fail-closed to latest or next. The preflight is dry-run only and runs before irreversible image publication. GitHub package authority remains the short-lived GITHUB_TOKEN; no token is written to package files, lockfiles, logs, or reports.

## Release, compatibility, migration, and rollback

This is an immutable release-workflow repair. No database migration or runtime API changes are introduced. RC2 tags and artifacts remain untouched; the coordinated train advances to RC3. Rollback is a normal PR revert before RC3 tagging.