### PR TITLE
fix(release): verify GitHub Packages dist-tags with npm CLI

### DIFF
--- a/.github/workflows/frontend-v6-release.yml
+++ b/.github/workflows/frontend-v6-release.yml
@@ -545,15 +545,41 @@ jobs:
             '.version == $version and .gitHead == $commit and
              ."dist.integrity" == $integrity' \
             <<< "${package_metadata}" >/dev/null
-          dist_tags="$(
-            npm view '@mss-boot-io/admin-web' dist-tags --json \
-              --registry=https://npm.pkg.github.com
-          )"
-          jq -e \
-            --arg tag "${NPM_DIST_TAG}" \
-            --arg version "${unprefixed_version}" \
-            '.[$tag] == $version' \
-            <<< "${dist_tags}" >/dev/null
+          tagged_version=''
+          for attempt in 1 2 3 4 5 6; do
+            dist_tags="$(
+              npm dist-tag ls '@mss-boot-io/admin-web' \
+                --registry=https://npm.pkg.github.com
+            )"
+            tag_record="$(
+              awk -v expected_tag="${NPM_DIST_TAG}" '
+                $1 == expected_tag ":" {
+                  count += 1
+                  version = $2
+                }
+                END {
+                  printf "%d\t%s\n", count, version
+                }
+              ' <<< "${dist_tags}"
+            )"
+            IFS=$'\t' read -r tag_count tagged_version <<< "${tag_record}"
+            if [[ "${tag_count}" == '1' ]]; then
+              if [[ "${tagged_version}" != "${unprefixed_version}" ]]; then
+                echo "npm dist-tag ${NPM_DIST_TAG} resolves to ${tagged_version}, expected ${unprefixed_version}" >&2
+                exit 1
+              fi
+              break
+            fi
+            if [[ "${tag_count}" != '0' ]]; then
+              echo "npm dist-tag ${NPM_DIST_TAG} returned ${tag_count} records" >&2
+              exit 1
+            fi
+            if [[ "${attempt}" == '6' ]]; then
+              echo "npm dist-tag ${NPM_DIST_TAG} did not resolve after bounded verification" >&2
+              exit 1
+            fi
+            sleep 5
+          done
           package_record="$(
             gh api "/orgs/${GITHUB_REPOSITORY_OWNER}/packages/npm/admin-web"
           )"

--- a/.mss/blueprints/management-system.yaml
+++ b/.mss/blueprints/management-system.yaml
@@ -11,13 +11,13 @@ spec:
   sourceProjectName: mss-boot-admin
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.3
+    version: v1.3.0-rc.4
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.3
+      version: v1.3.0-rc.4
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.3
+      version: 1.3.0-rc.4
   defaultOutputDirectory: .mss/output
   manifestPath: .mss/blueprint-manifest.json
   lockPath: .mss/lock.yaml

--- a/.mss/capabilities.yaml
+++ b/.mss/capabilities.yaml
@@ -877,9 +877,9 @@ spec:
       guidance: >-
         Treat Unreleased, planned, preview, branches, and local workspace replacements as non-stable.
         Published historical versions remain immutable and their candidate evidence is not reusable.
-        The active reviewed target is the v1.3.0-rc.3 preview for root, Framework, the importable Admin module,
+        The active reviewed target is the v1.3.0-rc.4 preview for root, Framework, the importable Admin module,
         and the sole Ant Design V6 frontend. Other alpha, beta, RC, or stable tags remain forbidden.
-        Complete release readiness begins only after one v1.3.0-rc.3 feature-freeze commit already
+        Complete release readiness begins only after one v1.3.0-rc.4 feature-freeze commit already
         merged into main is selected. An emergency
         patch requires a reviewed policy target change rather than a bypass.
         Publish Framework first, then the importable Admin module, then the complete frontend package,

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -239,40 +239,40 @@ spec:
       idempotent: true
 
     release-phase-evidence-plan:
-      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
-      description: Resolve the explicitly selected v1.3.0-rc.3 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
+      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.4 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
+      description: Resolve the explicitly selected v1.3.0-rc.4 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-phase-evidence-run:
-      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.3 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
+      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.4 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
       description: On one clean frozen commit, execute the scoped release Feature commands without a shell, retain per-command digests and logs, and fail when a selected command fails, times out, or still uses non-exact named Go test evidence.
       outputFormats: [json]
       category: release
 
     release-qualification-decision:
-      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.3 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
+      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.4 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
       description: Bind the Codex in-app Browser and external Blueprint rehearsal evidence to the exact frozen SHA while recording carry-forward and optional ObjectStore/RustFS decisions.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-readiness-attestation-create:
-      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
+      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.4 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
       description: Create the strict readiness metadata for one exact workflow run; the checked-in development policy permits checkpoint qualification only and cannot grant publication authority.
       outputFormats: [text]
       category: release
 
     release-readiness-attestation-verify:
-      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.3 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
+      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.4 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
       description: Reject an attestation unless its exact schema, version, commit, phase, policy digest, selected run identity, URL, and authority match the requested intent.
       outputFormats: [text]
       category: release
       idempotent: true
 
     release-readiness-run-verify:
-      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.3 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
+      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.4 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
       description: Read the specifically selected successful release-readiness workflow run and its run-named artifact, then require an exact publication attestation before a publishing workflow writes externally.
       outputFormats: [text]
       category: release

--- a/.mss/features/complete-admin-distribution-thin-host.yaml
+++ b/.mss/features/complete-admin-distribution-thin-host.yaml
@@ -11,7 +11,7 @@ metadata:
     domain: admin-distribution
     implementation-status: complete
     release-status: rc-qualification
-    target-version: v1.3.0-rc.3
+    target-version: v1.3.0-rc.4
     compatibility: coordinated-backend-frontend-version
     privacy: no-telemetry
 spec:
@@ -156,7 +156,7 @@ spec:
         - The nested Admin Go module uses admin/vX.Y.Z and all coordinated artifacts share the same exact semantic version, including prerelease identifiers.
         - Frontend qualification includes pack contents, integrity, SBOM, GitHub provenance attestation, and fail-closed credential handling.
         - Admin Web publishes first to GitHub Packages under the repository-linked @mss-boot-io scope; Thin Hosts authenticate without committing a token.
-        - The v1.3.0-rc.3 train is a prerelease and does not replace the current v1.2.3 stable release.
+        - The v1.3.0-rc.4 train is a prerelease and does not replace the current v1.2.3 stable release.
         - >-
           The immutable v1.3.0-rc.1 train remains partial evidence: Framework, Admin, and the
           frontend image published, while the frontend package, frontend GitHub Release, and root
@@ -166,6 +166,14 @@ spec:
           corrected multi-architecture frontend image published, while the frontend package,
           frontend GitHub Release, and root release did not publish because npm requires an
           explicit dist-tag when publishing a prerelease version.
+        - >-
+          The immutable v1.3.0-rc.3 train remains partial evidence: Framework, Admin, the
+          multi-architecture frontend image, and the Admin Web package published from one exact
+          commit. The frontend GitHub Release and root release did not publish because the
+          post-publication verifier queried GitHub Packages through `npm view ... dist-tags`,
+          which returned an empty result even after immutable package integrity reconciliation.
+          The rc.4 repair uses the npm CLI's supported `npm dist-tag ls` command with bounded,
+          read-only verification and never moves or overwrites rc.3 artifacts.
     - id: preserve-privacy-boundary
       title: Preserve the no-telemetry boundary
       description: Creation, installation, execution, verification, and upgrade remain local and collect no adopter data.

--- a/.mss/lock.yaml
+++ b/.mss/lock.yaml
@@ -5,13 +5,13 @@ metadata:
 spec:
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.3
+    version: v1.3.0-rc.4
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.3
+      version: v1.3.0-rc.4
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.3
+      version: 1.3.0-rc.4
   foundation:
     repository: mss-boot-io/mss-boot-admin
     version: 0.1.0

--- a/.mss/project.yaml
+++ b/.mss/project.yaml
@@ -11,13 +11,13 @@ spec:
   foundationVersion: 0.1.0
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.3
+    version: v1.3.0-rc.4
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.3
+      version: v1.3.0-rc.4
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.3
+      version: 1.3.0-rc.4
   repositoryLayout:
     kind: foundation
     backend: admin

--- a/.mss/release-policy.yaml
+++ b/.mss/release-policy.yaml
@@ -8,8 +8,8 @@ spec:
   requireMergedPullRequestSource: true
   currentStableVersion: v1.2.3
   currentStableCommit: 260d546851c58f7293b30e76b47d40d8e89f52fe
-  nextPublicVersion: v1.3.0-rc.3
-  distributionVersion: v1.3.0-rc.3
+  nextPublicVersion: v1.3.0-rc.4
+  distributionVersion: v1.3.0-rc.4
   distributionComponents: "root,framework,admin,frontend"
   publicationWorkflowsReady: true
   publicPrereleases: true

--- a/.mss/release-qualification.json
+++ b/.mss/release-qualification.json
@@ -1,6 +1,6 @@
 {
   "schema": "mss.io/release-qualification/v1",
-  "targetVersion": "v1.3.0-rc.3",
+  "targetVersion": "v1.3.0-rc.4",
   "features": [
     ".mss/features/complete-admin-distribution-thin-host.yaml"
   ],

--- a/admin/go.mod
+++ b/admin/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/pyroscope-go v1.4.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.10
-	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.3
+	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.4
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
+++ b/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
@@ -1,6 +1,6 @@
 # ADR: Complete Admin distribution and thin business hosts
 
-- Status: Accepted; v1.3.0-rc.3 preview qualification in progress
+- Status: Accepted; v1.3.0-rc.4 preview qualification in progress
 - Date: 2026-08-19
 - Owners: Admin, frontend, agent infrastructure, release engineering
 - Feature contract: `.mss/features/complete-admin-distribution-thin-host.yaml`
@@ -89,7 +89,7 @@ business files, and records a thin baseline only after all file operations and v
 
 Technical artifacts may use root, `mss-boot/`, `admin/`, and `web/antd-v6/` tag namespaces, but their
 exact semantic version, including a prerelease suffix, must match for a coordinated distribution. The
-current public consumption rehearsal uses `v1.3.0-rc.3`; it is marked as a prerelease and does not replace
+current public consumption rehearsal uses `v1.3.0-rc.4`; it is marked as a prerelease and does not replace
 the current `v1.2.3` stable release. Publication remains restricted to the exact merged-main commit and
 the protected Framework -> Admin -> Frontend -> Root release train.
 
@@ -102,6 +102,14 @@ The immutable `v1.3.0-rc.2` train also remains partial evidence. Framework, Admi
 multi-architecture frontend image published and passed identity checks, but npm rejected the prerelease
 package because the publish command omitted an explicit dist-tag. The repair assigns `next` to prereleases
 and `latest` to stable releases, adds a distribution-tag assertion, and advances the coordinated version.
+
+The immutable `v1.3.0-rc.3` train remains partial evidence as well. Framework, Admin, the corrected
+multi-architecture frontend image, and `@mss-boot-io/admin-web@1.3.0-rc.3` published from the same exact
+commit. Package integrity reconciliation succeeded on a clean rerun, but the post-publication verifier
+used `npm view <package> dist-tags --json`, which returns an empty result against GitHub Packages. The
+frontend GitHub Release and root Release were therefore not created. The repair uses the npm CLI's
+supported read-only `npm dist-tag ls <package>` interface with bounded verification and advances the
+coordinated version without moving or overwriting any rc.3 tag, package, or image.
 
 Before publication, rollback is a normal revert of the feature commits. After downstream adoption,
 rollback pins the previous Admin Distribution and restores the previous thin-host lock and manifest.

--- a/docs/docs/operations/admin-distribution-v1.3.0-rc.4.zh-CN.md
+++ b/docs/docs/operations/admin-distribution-v1.3.0-rc.4.zh-CN.md
@@ -1,11 +1,11 @@
 ---
-title: Admin Distribution v1.3.0-rc.3 预览版引用
+title: Admin Distribution v1.3.0-rc.4 预览版引用
 order: 35
 ---
 
-# Admin Distribution v1.3.0-rc.3 预览版引用
+# Admin Distribution v1.3.0-rc.4 预览版引用
 
-`v1.3.0-rc.3` 是完整 Admin Distribution 的公开预览版，不替代当前
+`v1.3.0-rc.4` 是完整 Admin Distribution 的公开预览版，不替代当前
 `v1.2.3` 稳定版。Root、Framework、Admin Go Module 与 Admin Web 使用同一个
 精确版本，并从同一个已合并到 `main` 的提交发布。
 
@@ -13,11 +13,11 @@ order: 35
 
 | 组件 | 引用 |
 | --- | --- |
-| Root | `v1.3.0-rc.3` |
-| Framework | `mss-boot/v1.3.0-rc.3` |
-| Admin Go Module | `admin/v1.3.0-rc.3` |
-| Admin Web | GitHub Packages：`@mss-boot-io/admin-web@1.3.0-rc.3` |
-| 前端镜像 | `ghcr.io/mss-boot-io/mss-boot-admin-antd-v6:v1.3.0-rc.3` |
+| Root | `v1.3.0-rc.4` |
+| Framework | `mss-boot/v1.3.0-rc.4` |
+| Admin Go Module | `admin/v1.3.0-rc.4` |
+| Admin Web | GitHub Packages：`@mss-boot-io/admin-web@1.3.0-rc.4` |
+| 前端镜像 | `ghcr.io/mss-boot-io/mss-boot-admin-antd-v6:v1.3.0-rc.4` |
 
 ## rc.1 状态
 
@@ -33,14 +33,23 @@ Admin Web 包、前端 GitHub Release 与 Root Release 未发布。镜像身份�
 版本，因为命令没有显式指定 dist-tag。修复通过新的 Pull Request 合并，预发布版本固定使用 `next`、正式版本固定使用
 `latest`，并推进到 `rc.3`；不会移动、覆盖或复用任何 `rc.2` 标签和制品。
 
+## rc.3 状态
+
+`v1.3.0-rc.3` 继续保留为不可变的部分发布记录：Framework、Admin、多架构前端镜像以及
+`@mss-boot-io/admin-web@1.3.0-rc.3` 已从同一个精确提交发布。安全恢复执行证明远端包完整性与镜像摘要
+完全一致，既有包和镜像均未被覆盖；但发布后校验使用了 `npm view <package> dist-tags --json`，GitHub
+Packages 对该字段查询持续返回空结果，因此前端 GitHub Release 与 Root Release 未发布。`rc.4` 改用 npm
+CLI 官方的只读 `npm dist-tag ls <package>` 命令，并进行有界重试与精确版本比对；不会移动、覆盖或复用任何
+`rc.3` 标签、包版本或镜像。
+
 ## 后端引用
 
 Thin Host 的 `go.mod` 必须同时精确固定 Admin 与 Framework：
 
 ```go
 require (
-    github.com/mss-boot-io/mss-boot-admin/admin v1.3.0-rc.3
-    github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.3
+    github.com/mss-boot-io/mss-boot-admin/admin v1.3.0-rc.4
+    github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.4
 )
 ```
 

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -24,7 +24,7 @@ class ReleasePolicyTest(unittest.TestCase):
     def setUp(self):
         self.policy = POLICY.load_policy(POLICY_PATH)
 
-    def test_v130_rc3_matches_every_distribution_component_namespace(self):
+    def test_v130_rc4_matches_every_distribution_component_namespace(self):
         cases = {
             "root": "v1.3.0-rc.4",
             "framework": "mss-boot/v1.3.0-rc.4",
@@ -54,7 +54,7 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertEqual(self.policy["releaseBranch"], "main")
         self.assertIs(self.policy["requireMergedPullRequestSource"], True)
 
-    def test_policy_rejects_versions_other_than_v130_rc3(self):
+    def test_policy_rejects_versions_other_than_v130_rc4(self):
         for version in (
             "v1.0.1",
             "v1.1.0",

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -26,20 +26,20 @@ class ReleasePolicyTest(unittest.TestCase):
 
     def test_v130_rc3_matches_every_distribution_component_namespace(self):
         cases = {
-            "root": "v1.3.0-rc.3",
-            "framework": "mss-boot/v1.3.0-rc.3",
-            "admin": "admin/v1.3.0-rc.3",
-            "frontend": "web/antd-v6/v1.3.0-rc.3",
-            "docs": "docs/v1.3.0-rc.3",
+            "root": "v1.3.0-rc.4",
+            "framework": "mss-boot/v1.3.0-rc.4",
+            "admin": "admin/v1.3.0-rc.4",
+            "frontend": "web/antd-v6/v1.3.0-rc.4",
+            "docs": "docs/v1.3.0-rc.4",
         }
         for component, tag in cases.items():
             with self.subTest(component=component):
                 POLICY.check_public_ref(
-                    self.policy, component, "v1.3.0-rc.3", tag, intent="qualify"
+                    self.policy, component, "v1.3.0-rc.4", tag, intent="qualify"
                 )
 
         self.assertEqual(
-            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.3"),
+            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.4"),
             {component: cases[component] for component in POLICY.COORDINATED_COMPONENTS},
         )
 
@@ -47,7 +47,7 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertIs(self.policy["publicationWorkflowsReady"], True)
         self.assertIs(self.policy["publicPrereleases"], True)
         POLICY.check_public_ref(
-            self.policy, "root", "v1.3.0-rc.3", "v1.3.0-rc.3"
+            self.policy, "root", "v1.3.0-rc.4", "v1.3.0-rc.4"
         )
 
     def test_policy_requires_pr_merged_main_release_source(self):
@@ -84,15 +84,15 @@ class ReleasePolicyTest(unittest.TestCase):
             POLICY.check_public_ref(
                 self.policy,
                 "framework",
-                "v1.3.0-rc.3",
-                "v1.3.0-rc.3",
+                "v1.3.0-rc.4",
+                "v1.3.0-rc.4",
                 intent="qualify",
             )
 
     def test_policy_rejects_distribution_version_or_component_drift(self):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
-            ("  distributionVersion: v1.3.0-rc.3\n", "  distributionVersion: v1.3.1\n"),
+            ("  distributionVersion: v1.3.0-rc.4\n", "  distributionVersion: v1.3.1\n"),
             (
                 '  distributionComponents: "root,framework,admin,frontend"\n',
                 '  distributionComponents: "root,framework,frontend"\n',
@@ -110,7 +110,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
             ("  publicPrereleases: true\n", "  publicPrereleases: false\n"),
-            ("  nextPublicVersion: v1.3.0-rc.3\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
+            ("  nextPublicVersion: v1.3.0-rc.4\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
             ("  currentStableVersion: v1.2.3\n", "  currentStableVersion: v1.2.3-rc.1\n"),
         )
         for old, new in replacements:
@@ -120,7 +120,7 @@ class ReleasePolicyTest(unittest.TestCase):
                     content = original.replace(old, new)
                     if "nextPublicVersion" in new:
                         content = content.replace(
-                            "  distributionVersion: v1.3.0-rc.3\n",
+                            "  distributionVersion: v1.3.0-rc.4\n",
                             "  distributionVersion: v1.3.0-rc.01\n",
                         )
                     candidate.write_text(content, encoding="utf-8")
@@ -131,7 +131,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         for suffix in (
             "  unexpected: true\n",
-            "  nextPublicVersion: v1.3.0-rc.3\n",
+            "  nextPublicVersion: v1.3.0-rc.4\n",
         ):
             with self.subTest(suffix=suffix.strip()):
                 with tempfile.TemporaryDirectory() as directory:

--- a/tools/release/test_release_phase_evidence.py
+++ b/tools/release/test_release_phase_evidence.py
@@ -214,7 +214,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
             EVIDENCE.validate_binding(
                 root,
                 policy_path=policy,
-                target_version="v1.3.0-rc.3",
+                target_version="v1.3.0-rc.4",
                 commit=commit,
                 require_clean=True,
             )
@@ -223,7 +223,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
                 EVIDENCE.validate_binding(
                     root,
                     policy_path=policy,
-                    target_version="v1.3.0-rc.3",
+                    target_version="v1.3.0-rc.4",
                     commit=commit,
                     require_clean=True,
                 )

--- a/tools/release/test_release_qualification_decision.py
+++ b/tools/release/test_release_qualification_decision.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 import release_qualification_decision as DECISION  # noqa: E402
 
 
-TARGET_VERSION = "v1.3.0-rc.3"
+TARGET_VERSION = "v1.3.0-rc.4"
 
 
 class ReleaseQualificationDecisionTest(unittest.TestCase):

--- a/tools/release/test_release_readiness_attestation.py
+++ b/tools/release/test_release_readiness_attestation.py
@@ -50,7 +50,7 @@ class ReleaseReadinessAttestationTest(unittest.TestCase):
     def ready_policy(self, directory: str) -> Path:
         return self.policy_with_readiness(directory, True)
 
-    def test_checkpoint_attestation_binds_exact_v130_rc3_metadata(self):
+    def test_checkpoint_attestation_binds_exact_v130_rc4_metadata(self):
         attestation = self.checkpoint()
         self.assertEqual(set(attestation), ATTESTATION.REQUIRED_KEYS)
         self.assertEqual(attestation["schema"], ATTESTATION.SCHEMA)

--- a/tools/release/test_release_readiness_attestation.py
+++ b/tools/release/test_release_readiness_attestation.py
@@ -20,7 +20,7 @@ RUN_ID = 123456789
 RUN_URL = (
     "https://github.com/mss-boot-io/mss-boot-admin/actions/runs/123456789"
 )
-TARGET_VERSION = "v1.3.0-rc.3"
+TARGET_VERSION = "v1.3.0-rc.4"
 
 
 class ReleaseReadinessAttestationTest(unittest.TestCase):

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -93,7 +93,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         selected = PHASE_EVIDENCE.load_qualification(
             REPOSITORY_ROOT,
             Path(".mss/release-qualification.json"),
-            "v1.3.0-rc.3",
+            "v1.3.0-rc.4",
         )
         self.assertEqual(
             [path.relative_to(REPOSITORY_ROOT).as_posix() for path in selected],

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -89,7 +89,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(self.step("Setup pnpm")["with"]["version"], "9.15.9")
 
-    def test_v130_rc3_qualification_selects_the_distribution_feature(self):
+    def test_v130_rc4_qualification_selects_the_distribution_feature(self):
         selected = PHASE_EVIDENCE.load_qualification(
             REPOSITORY_ROOT,
             Path(".mss/release-qualification.json"),
@@ -112,7 +112,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             )
         )
 
-    def test_v130_rc3_feature_freeze_commands_are_exact_and_executable(self):
+    def test_v130_rc4_feature_freeze_commands_are_exact_and_executable(self):
         feature_path = (
             REPOSITORY_ROOT
             / ".mss"

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -442,8 +442,17 @@ class WorkflowGovernanceTest(unittest.TestCase):
         )
         self.assertIn('.visibility == "private"', verify_package["run"])
         self.assertIn('.visibility == "public"', verify_package["run"])
-        self.assertIn("dist-tags", verify_package["run"])
-        self.assertIn('.[$tag] == $version', verify_package["run"])
+        self.assertIn("npm dist-tag ls", verify_package["run"])
+        self.assertNotIn(
+            "npm view '@mss-boot-io/admin-web' dist-tags",
+            verify_package["run"],
+        )
+        self.assertIn('$1 == expected_tag ":"', verify_package["run"])
+        self.assertIn(
+            "did not resolve after bounded verification",
+            verify_package["run"],
+        )
+        self.assertIn("sleep 5", verify_package["run"])
         self.assertEqual(
             verify_package["env"]["NPM_DIST_TAG"],
             "${{ steps.version.outputs.npm_dist_tag }}",


### PR DESCRIPTION
## Outcome

- Advances the coordinated preview target to `v1.3.0-rc.4`; RC3 tags, package, and image remain immutable partial-release evidence.
- Replaces the unsupported empty `npm view <package> dist-tags --json` result with the npm CLI supported read-only `npm dist-tag ls <package>` command.
- Parses exactly one requested tag, fails immediately on a wrong or duplicate version, and bounds absent-tag propagation checks to six attempts.
- Records why RC3 stopped after publishing Framework, Admin, the multi-architecture image, and the Admin Web package; frontend GitHub Release and Root were not published.

## Evidence

- RC3 package publication and immutable integrity reconciliation succeeded; attempts 1 and 2 both stopped only in post-publication dist-tag verification.
- Frontend release workflow YAML parsed successfully.
- `npm dist-tag ls react` on npm 11 confirmed the official `tag: version` output shape used by the strict parser.

## Validation

- `python3 -m unittest discover -s tools/release -p 'test_*.py'` (107 passed)
- `GOFLAGS=-mod=readonly go test -count=1 ./internal/mss/project ./internal/mss/blueprint ./internal/mss/app`
- `corepack pnpm@9.15.9 --dir docs build`
- `GOFLAGS=-mod=readonly go run ./cmd/mss verify --changed`
- `git diff --check`

## Security impact

- The registry check remains read-only and continues to use the short-lived workflow GITHUB_TOKEN; no token is printed, persisted, or added to artifacts.
- A missing tag is retried only within a fixed bound. A wrong version, duplicate tag record, missing authority, or integrity mismatch fails closed before any later release step.
- No application authentication, authorization, runtime dependency, or production traffic behavior changes.