### PR TITLE
fix(release): enforce Thin Host eval before rc6

### DIFF
--- a/.mss/blueprints/management-system.yaml
+++ b/.mss/blueprints/management-system.yaml
@@ -3,7 +3,7 @@ kind: ApplicationBlueprint
 metadata:
   name: management-system
   displayName: Agent-Native Management System
-  version: 0.4.2
+  version: 0.4.3
 spec:
   sourceMode: git-tracked
   templateRoot: templates/application
@@ -11,13 +11,13 @@ spec:
   sourceProjectName: mss-boot-admin
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.5
+    version: v1.3.0-rc.6
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.5
+      version: v1.3.0-rc.6
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.5
+      version: 1.3.0-rc.6
   defaultOutputDirectory: .mss/output
   manifestPath: .mss/blueprint-manifest.json
   lockPath: .mss/lock.yaml

--- a/.mss/capabilities.yaml
+++ b/.mss/capabilities.yaml
@@ -877,9 +877,9 @@ spec:
       guidance: >-
         Treat Unreleased, planned, preview, branches, and local workspace replacements as non-stable.
         Published historical versions remain immutable and their candidate evidence is not reusable.
-        The active reviewed target is the v1.3.0-rc.5 preview for root, Framework, the importable Admin module,
+        The active reviewed target is the v1.3.0-rc.6 preview for root, Framework, the importable Admin module,
         and the sole Ant Design V6 frontend. Other alpha, beta, RC, or stable tags remain forbidden.
-        Complete release readiness begins only after one v1.3.0-rc.5 feature-freeze commit already
+        Complete release readiness begins only after one v1.3.0-rc.6 feature-freeze commit already
         merged into main is selected. An emergency
         patch requires a reviewed policy target change rather than a bypass.
         Publish Framework first, then the importable Admin module, then the complete frontend package,

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -239,40 +239,40 @@ spec:
       idempotent: true
 
     release-phase-evidence-plan:
-      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.5 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
-      description: Resolve the explicitly selected v1.3.0-rc.5 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
+      command: python3 tools/release/release_phase_evidence.py plan --target-version v1.3.0-rc.6 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root|post-publication> --output .mss/reports/release-phase-plan.json
+      description: Resolve the explicitly selected v1.3.0-rc.6 Feature contracts into a shell-free, phase-scoped command plan while retaining manual, report, and non-exact evidence as release-manager review items.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-phase-evidence-run:
-      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.5 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
+      command: python3 tools/release/release_phase_evidence.py run --target-version v1.3.0-rc.6 --commit <full-sha> --phase feature-freeze --output .mss/reports/release-phase-command-evidence.json
       description: On one clean frozen commit, execute the scoped release Feature commands without a shell, retain per-command digests and logs, and fail when a selected command fails, times out, or still uses non-exact named Go test evidence.
       outputFormats: [json]
       category: release
 
     release-qualification-decision:
-      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.5 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
+      command: python3 tools/release/release_qualification_decision.py --target-version v1.3.0-rc.6 --commit <full-sha> --phase feature-freeze --browser-evidence-commit <full-sha> --browser-evidence-ref <reference> --blueprint-evidence-commit <full-sha> --blueprint-evidence-ref <reference> --output .mss/reports/release-qualification-decision.json
       description: Bind the Codex in-app Browser and external Blueprint rehearsal evidence to the exact frozen SHA while recording carry-forward and optional ObjectStore/RustFS decisions.
       outputFormats: [json]
       category: release
       idempotent: true
 
     release-readiness-attestation-create:
-      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.5 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
+      command: python3 tools/release/release_readiness_attestation.py create --output <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.6 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --publication-authority <true|false>
       description: Create the strict readiness metadata for one exact workflow run; the checked-in development policy permits checkpoint qualification only and cannot grant publication authority.
       outputFormats: [text]
       category: release
 
     release-readiness-attestation-verify:
-      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.5 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
+      command: python3 tools/release/release_readiness_attestation.py verify --attestation <attestation.json> --policy .mss/release-policy.yaml --target-version v1.3.0-rc.6 --commit <full-sha> --phase <checkpoint|feature-freeze|pre-framework|pre-root> --workflow-run-id <run-id> --workflow-run-url <run-url> --intent <qualify|publish>
       description: Reject an attestation unless its exact schema, version, commit, phase, policy digest, selected run identity, URL, and authority match the requested intent.
       outputFormats: [text]
       category: release
       idempotent: true
 
     release-readiness-run-verify:
-      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.5 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
+      command: bash tools/release/verify_readiness_run.sh --repository <owner/repository> --run-id <run-id> --target-version v1.3.0-rc.6 --commit <full-sha> --phase <pre-framework|pre-root> --policy .mss/release-policy.yaml
       description: Read the specifically selected successful release-readiness workflow run and its run-named artifact, then require an exact publication attestation before a publishing workflow writes externally.
       outputFormats: [text]
       category: release

--- a/.mss/evals/catalog.yaml
+++ b/.mss/evals/catalog.yaml
@@ -2,7 +2,7 @@ apiVersion: mss.io/v1alpha1
 kind: AgentEvaluationCatalog
 metadata:
   project: mss-boot-admin
-  version: 0.3.0
+  version: 0.3.1
 spec:
   cases:
     - id: project-onboarding
@@ -39,11 +39,12 @@ spec:
 
     - id: downstream-application-blueprint
       title: Agent can plan a complete standalone management-system repository
-      description: Validates the versioned Blueprint, Git-tracked file selection, project identity rewrites, Foundation Lock, and three-way upgrade baseline.
+      description: Validates the compact Thin Host Blueprint, project identity rewrites, Foundation Lock, and three-way upgrade baseline without copying Foundation core sources.
       tags: [application, blueprint, upgrade]
       checks:
         - type: application-blueprint-plan
-          minimum: 500
+          minimum: 30
+          maximum: 64
 
     - id: full-verification-plan
       title: Agent can derive the complete repository validation plan

--- a/.mss/features/complete-admin-distribution-thin-host.yaml
+++ b/.mss/features/complete-admin-distribution-thin-host.yaml
@@ -11,7 +11,7 @@ metadata:
     domain: admin-distribution
     implementation-status: complete
     release-status: rc-qualification
-    target-version: v1.3.0-rc.5
+    target-version: v1.3.0-rc.6
     compatibility: coordinated-backend-frontend-version
     privacy: no-telemetry
 spec:
@@ -157,7 +157,7 @@ spec:
         - The nested Admin Go module uses admin/vX.Y.Z and all coordinated artifacts share the same exact semantic version, including prerelease identifiers.
         - Frontend qualification includes pack contents, integrity, SBOM, GitHub provenance attestation, and fail-closed credential handling.
         - Admin Web publishes first to GitHub Packages under the repository-linked @mss-boot-io scope; Thin Hosts authenticate without committing a token.
-        - The v1.3.0-rc.5 train is a prerelease and does not replace the current v1.2.3 stable release.
+        - The v1.3.0-rc.6 train is a prerelease and does not replace the current v1.2.3 stable release.
         - >-
           The immutable v1.3.0-rc.1 train remains partial evidence: Framework, Admin, and the
           frontend image published, while the frontend package, frontend GitHub Release, and root
@@ -175,6 +175,17 @@ spec:
           which returned an empty result even after immutable package integrity reconciliation.
           The rc.4 repair uses the npm CLI's supported `npm dist-tag ls` command with bounded,
           read-only verification and never moves or overwrites rc.3 artifacts.
+        - >-
+          The immutable v1.3.0-rc.4 train published Framework, Admin, and frontend artifacts,
+          but its root Release remained unpublished after the retained Thin Host exposed the
+          Supplier migration-order collision. RC5 repaired the migration and menu projection
+          without moving or overwriting rc.4 artifacts.
+        - >-
+          The immutable v1.3.0-rc.5 train published Framework, Admin, frontend package and image,
+          and the root image from one exact commit. Its root candidate Release remained
+          unpublished because the Agent evaluation catalog still expected at least 500 copied
+          application files after the supported Blueprint became a 31-file Thin Host. RC6 fixes
+          that stale evaluation and executes it during feature freeze before any public tag.
     - id: preserve-privacy-boundary
       title: Preserve the no-telemetry boundary
       description: Creation, installation, execution, verification, and upgrade remain local and collect no adopter data.
@@ -254,6 +265,8 @@ spec:
       phase: feature-freeze
       required: true
       evidence:
+        - type: command
+          value: go run ./cmd/mss eval run --all --format json
         - type: test
           value: Thin-host generation, path attack, unknown-file preservation, and two-run drift suite
         - type: report
@@ -317,6 +330,7 @@ spec:
     changed: go run ./cmd/mss verify --changed
     all: go run ./cmd/mss verify --all
     custom:
+      - go run ./cmd/mss eval run --all --format json
       - cd admin && go test ./... && go vet ./...
       - bash tools/compatibility/test-admin-external-consumer.sh
       - corepack pnpm@10.34.5 --dir web/antd-v6 run deps:check

--- a/.mss/lock.yaml
+++ b/.mss/lock.yaml
@@ -5,20 +5,20 @@ metadata:
 spec:
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.5
+    version: v1.3.0-rc.6
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.5
+      version: v1.3.0-rc.6
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.5
+      version: 1.3.0-rc.6
   foundation:
     repository: mss-boot-io/mss-boot-admin
     version: 0.1.0
     channel: development
   blueprint:
     name: management-system
-    version: 0.4.2
+    version: 0.4.3
   contracts:
     project: v1alpha1
     capabilityCatalog: v1alpha1

--- a/.mss/project.yaml
+++ b/.mss/project.yaml
@@ -11,13 +11,13 @@ spec:
   foundationVersion: 0.1.0
   distribution:
     name: mss-boot-admin
-    version: v1.3.0-rc.5
+    version: v1.3.0-rc.6
     backend:
       module: github.com/mss-boot-io/mss-boot-admin/admin
-      version: v1.3.0-rc.5
+      version: v1.3.0-rc.6
     frontend:
       package: "@mss-boot-io/admin-web"
-      version: 1.3.0-rc.5
+      version: 1.3.0-rc.6
   repositoryLayout:
     kind: foundation
     backend: admin

--- a/.mss/release-policy.yaml
+++ b/.mss/release-policy.yaml
@@ -1,15 +1,15 @@
 apiVersion: mss.io/v1alpha1
 kind: ReleasePolicy
 metadata:
-  name: foundation-v1-3-0-rc-5-release
+  name: foundation-v1-3-0-rc-6-release
 spec:
   mode: development-first
   releaseBranch: main
   requireMergedPullRequestSource: true
   currentStableVersion: v1.2.3
   currentStableCommit: 260d546851c58f7293b30e76b47d40d8e89f52fe
-  nextPublicVersion: v1.3.0-rc.5
-  distributionVersion: v1.3.0-rc.5
+  nextPublicVersion: v1.3.0-rc.6
+  distributionVersion: v1.3.0-rc.6
   distributionComponents: "root,framework,admin,frontend"
   publicationWorkflowsReady: true
   publicPrereleases: true

--- a/.mss/release-qualification.json
+++ b/.mss/release-qualification.json
@@ -1,6 +1,6 @@
 {
   "schema": "mss.io/release-qualification/v1",
-  "targetVersion": "v1.3.0-rc.5",
+  "targetVersion": "v1.3.0-rc.6",
   "features": [
     ".mss/features/complete-admin-distribution-thin-host.yaml"
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,18 @@ tag namespaces.
 
 ## [Unreleased]
 
-Target: **v1.3.0-rc.5** for the root foundation, `mss-boot/v1.3.0-rc.5` for the
-Framework, `admin/v1.3.0-rc.5` for the importable Admin module, and
-`web/antd-v6/v1.3.0-rc.5` for Admin Web. Publication requires one exact clean
+Target: **v1.3.0-rc.6** for the root foundation, `mss-boot/v1.3.0-rc.6` for the
+Framework, `admin/v1.3.0-rc.6` for the importable Admin module, and
+`web/antd-v6/v1.3.0-rc.6` for Admin Web. Publication requires one exact clean
 commit already merged into `origin/main`; local or topic-branch evidence is
 preliminary only.
 
-The immutable v1.3.0-rc.4 Framework, Admin, and frontend releases were published
-from `3dddd01c4d3b70be13fb9ff53438505805ea6087`. The root tag was also created,
-but its GitHub Release did not publish. A retained external Thin Host then exposed
-that globally sorting core and business migration IDs let the core example cleanup
-run after the Supplier authorization seed, removing the authorized menu. The root
-release test also dirtied `go.work.sum` before a Blueprint evaluation that correctly
-requires a clean Foundation checkout. RC5 is the forward repair; no RC4 tag,
+The immutable v1.3.0-rc.5 Framework, Admin, frontend package and image, and root
+image were published from `49158fd65d577a5a94c41d428ab6ad458619a0d9`.
+Its root candidate Release stopped before publication because the Agent evaluation
+catalog still required at least 500 copied application files after the supported
+Blueprint had intentionally become a 31-file Thin Host. RC6 corrects that stale
+contract and moves the complete evaluation into feature freeze; no RC5 tag,
 package, image, or Release is moved or overwritten.
 
 ### Added
@@ -33,6 +32,11 @@ package, image, or Release is moved or overwritten.
 
 ### Changed
 
+- Bound the downstream Blueprint evaluation to a compact 30-64 file Thin Host
+  envelope, rejecting both incomplete hosts and regressions that copy Foundation
+  core sources.
+- Run the complete Agent evaluation during feature freeze so this contract fails
+  before any Framework, Admin, frontend, or root tag is created.
 - Download Admin module dependencies with `GOWORK=off` and assert the release
   checkout remains unchanged before Blueprint evaluations.
 - Add an explicit module-scoped marker for compatibility migrations that query a

--- a/admin/go.mod
+++ b/admin/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/grafana/pyroscope-go v1.4.1
 	github.com/larksuite/oapi-sdk-go/v3 v3.9.10
-	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.5
+	github.com/mss-boot-io/mss-boot-admin/mss-boot v1.3.0-rc.6
 	github.com/nsqio/go-nsq v1.1.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/robfig/cron/v3 v3.0.1

--- a/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
+++ b/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
@@ -1,6 +1,6 @@
 # ADR: Complete Admin distribution and thin business hosts
 
-- Status: Accepted; v1.3.0-rc.5 preview qualification in progress
+- Status: Accepted; v1.3.0-rc.6 preview qualification in progress
 - Date: 2026-08-19
 - Owners: Admin, frontend, agent infrastructure, release engineering
 - Feature contract: `.mss/features/complete-admin-distribution-thin-host.yaml`
@@ -89,7 +89,7 @@ business files, and records a thin baseline only after all file operations and v
 
 Technical artifacts may use root, `mss-boot/`, `admin/`, and `web/antd-v6/` tag namespaces, but their
 exact semantic version, including a prerelease suffix, must match for a coordinated distribution. The
-current public consumption rehearsal uses `v1.3.0-rc.5`; it is marked as a prerelease and does not replace
+current public consumption rehearsal uses `v1.3.0-rc.6`; it is marked as a prerelease and does not replace
 the current `v1.2.3` stable release. Publication remains restricted to the exact merged-main commit and
 the protected Framework -> Admin -> Frontend -> Root release train.
 

--- a/internal/mss/eval/eval.go
+++ b/internal/mss/eval/eval.go
@@ -63,6 +63,7 @@ type CheckSpec struct {
 	Path    string `yaml:"path,omitempty" json:"path,omitempty"`
 	Mode    string `yaml:"mode,omitempty" json:"mode,omitempty"`
 	Minimum int    `yaml:"minimum,omitempty" json:"minimum,omitempty"`
+	Maximum int    `yaml:"maximum,omitempty" json:"maximum,omitempty"`
 }
 
 // Report is persisted for agents, CI, and release review.
@@ -175,6 +176,15 @@ func (c *Catalog) Validate() error {
 			}
 			if check.Minimum < 0 {
 				problems = append(problems, checkPrefix+".minimum must be non-negative")
+			}
+			if check.Maximum < 0 {
+				problems = append(problems, checkPrefix+".maximum must be non-negative")
+			}
+			if check.Maximum > 0 && check.Type != "application-blueprint-plan" {
+				problems = append(problems, checkPrefix+".maximum is supported only for application-blueprint-plan")
+			}
+			if check.Maximum > 0 && check.Minimum > check.Maximum {
+				problems = append(problems, checkPrefix+".minimum must not exceed maximum")
 			}
 		}
 	}
@@ -301,7 +311,7 @@ func runCheck(ctx context.Context, root string, projectContext *project.Context,
 	case "module-generation-plan":
 		value, err = checkModuleGeneration(root, check.Path, check.Minimum)
 	case "application-blueprint-plan":
-		value, err = checkApplicationBlueprint(ctx, root, check.Minimum)
+		value, err = checkApplicationBlueprint(ctx, root, check.Minimum, check.Maximum)
 	case "feature-spec":
 		value, err = checkFeatureSpec(root, check.Path)
 	case "feature-plan":
@@ -459,7 +469,7 @@ func checkFeaturePlan(root, inputPath string, minimum int) (map[string]any, erro
 	}, nil
 }
 
-func checkApplicationBlueprint(ctx context.Context, root string, minimum int) (map[string]any, error) {
+func checkApplicationBlueprint(ctx context.Context, root string, minimum, maximum int) (map[string]any, error) {
 	plan, err := blueprint.Generate(ctx, blueprint.Options{
 		FoundationRoot: root,
 		Application: blueprint.Application{
@@ -475,8 +485,8 @@ func checkApplicationBlueprint(ctx context.Context, root string, minimum int) (m
 	if !plan.DryRun || !plan.Success {
 		return nil, errors.New("application Blueprint plan must be a successful dry-run")
 	}
-	if plan.TotalFiles < minimum {
-		return nil, fmt.Errorf("application Blueprint planned %d files, expected at least %d", plan.TotalFiles, minimum)
+	if err := validateApplicationBlueprintSize(plan.TotalFiles, minimum, maximum); err != nil {
+		return nil, err
 	}
 	if plan.FoundationCommit == "" {
 		return nil, errors.New("application Blueprint plan does not record a foundation commit")
@@ -492,7 +502,19 @@ func checkApplicationBlueprint(ctx context.Context, root string, minimum int) (m
 		"files":            plan.TotalFiles,
 		"bytes":            plan.TotalBytes,
 		"actions":          actions,
+		"minimumFiles":     minimum,
+		"maximumFiles":     maximum,
 	}, nil
+}
+
+func validateApplicationBlueprintSize(totalFiles, minimum, maximum int) error {
+	if totalFiles < minimum {
+		return fmt.Errorf("application Blueprint planned %d files, expected at least %d", totalFiles, minimum)
+	}
+	if maximum > 0 && totalFiles > maximum {
+		return fmt.Errorf("application Blueprint planned %d files, expected at most %d", totalFiles, maximum)
+	}
+	return nil
 }
 
 func checkValidationPlan(projectContext *project.Context, mode string, minimum int) (map[string]any, error) {

--- a/internal/mss/eval/eval_test.go
+++ b/internal/mss/eval/eval_test.go
@@ -27,6 +27,68 @@ func TestCatalogRejectsDuplicateCases(t *testing.T) {
 	}
 }
 
+func TestCatalogRejectsInvertedBlueprintBounds(t *testing.T) {
+	catalog := &Catalog{
+		APIVersion: "mss.io/v1alpha1",
+		Kind:       "AgentEvaluationCatalog",
+		Metadata:   CatalogMetadata{Project: "fixture", Version: "0.1.0"},
+		Spec: CatalogSpec{Cases: []Case{{
+			ID:    "application-blueprint",
+			Title: "Application Blueprint",
+			Checks: []CheckSpec{{
+				Type:    "application-blueprint-plan",
+				Minimum: 64,
+				Maximum: 30,
+			}},
+		}}},
+	}
+	if err := catalog.Validate(); err == nil || !strings.Contains(err.Error(), "minimum must not exceed maximum") {
+		t.Fatalf("expected inverted Blueprint bounds error, got %v", err)
+	}
+}
+
+func TestCatalogRejectsMaximumForUnboundedCheck(t *testing.T) {
+	catalog := &Catalog{
+		APIVersion: "mss.io/v1alpha1",
+		Kind:       "AgentEvaluationCatalog",
+		Metadata:   CatalogMetadata{Project: "fixture", Version: "0.1.0"},
+		Spec: CatalogSpec{Cases: []Case{{
+			ID:     "mcp-tools",
+			Title:  "MCP tools",
+			Checks: []CheckSpec{{Type: "mcp-tools", Maximum: 20}},
+		}}},
+	}
+	if err := catalog.Validate(); err == nil || !strings.Contains(err.Error(), "maximum is supported only") {
+		t.Fatalf("expected unsupported maximum error, got %v", err)
+	}
+}
+
+func TestApplicationBlueprintSizeEnforcesThinHostBounds(t *testing.T) {
+	tests := []struct {
+		name       string
+		totalFiles int
+		want       string
+	}{
+		{name: "within bounds", totalFiles: 31},
+		{name: "incomplete host", totalFiles: 29, want: "expected at least 30"},
+		{name: "copied foundation sources", totalFiles: 500, want: "expected at most 64"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateApplicationBlueprintSize(test.totalFiles, 30, 64)
+			if test.want == "" {
+				if err != nil {
+					t.Fatalf("validate Thin Host file count: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validate Thin Host file count error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestRunMCPToolsEvaluation(t *testing.T) {
 	root := writeEvaluationFixture(t)
 	report, err := Run(context.Background(), root, []string{"mcp-project-tools"})

--- a/mss-boot/CHANGELOG.md
+++ b/mss-boot/CHANGELOG.md
@@ -6,7 +6,7 @@ and the project uses semantic versioning for nested-module releases.
 
 ## [Unreleased]
 
-Target: **mss-boot/v1.3.0-rc.5**. This synchronized prerelease remains aligned
+Target: **mss-boot/v1.3.0-rc.6**. This synchronized prerelease remains aligned
 with the Admin module, Admin Web package, and root distribution from one exact
 merged-main commit.
 
@@ -18,6 +18,8 @@ merged-main commit.
 
 ### Changed
 
+- Requalify the unchanged Framework API from the RC6 merged-main repair commit so
+  the coordinated distribution retains one exact source identity.
 - Keep core and business registration sets independently executable so the Admin
   composition root can enforce Core-before-Business migration phases without
   adding Admin-specific behavior to the Framework.

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -24,22 +24,22 @@ class ReleasePolicyTest(unittest.TestCase):
     def setUp(self):
         self.policy = POLICY.load_policy(POLICY_PATH)
 
-    def test_v130_rc4_matches_every_distribution_component_namespace(self):
+    def test_v130_rc6_matches_every_distribution_component_namespace(self):
         cases = {
-            "root": "v1.3.0-rc.5",
-            "framework": "mss-boot/v1.3.0-rc.5",
-            "admin": "admin/v1.3.0-rc.5",
-            "frontend": "web/antd-v6/v1.3.0-rc.5",
-            "docs": "docs/v1.3.0-rc.5",
+            "root": "v1.3.0-rc.6",
+            "framework": "mss-boot/v1.3.0-rc.6",
+            "admin": "admin/v1.3.0-rc.6",
+            "frontend": "web/antd-v6/v1.3.0-rc.6",
+            "docs": "docs/v1.3.0-rc.6",
         }
         for component, tag in cases.items():
             with self.subTest(component=component):
                 POLICY.check_public_ref(
-                    self.policy, component, "v1.3.0-rc.5", tag, intent="qualify"
+                    self.policy, component, "v1.3.0-rc.6", tag, intent="qualify"
                 )
 
         self.assertEqual(
-            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.5"),
+            POLICY.coordinated_tags(self.policy, "v1.3.0-rc.6"),
             {component: cases[component] for component in POLICY.COORDINATED_COMPONENTS},
         )
 
@@ -47,14 +47,14 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertIs(self.policy["publicationWorkflowsReady"], True)
         self.assertIs(self.policy["publicPrereleases"], True)
         POLICY.check_public_ref(
-            self.policy, "root", "v1.3.0-rc.5", "v1.3.0-rc.5"
+            self.policy, "root", "v1.3.0-rc.6", "v1.3.0-rc.6"
         )
 
     def test_policy_requires_pr_merged_main_release_source(self):
         self.assertEqual(self.policy["releaseBranch"], "main")
         self.assertIs(self.policy["requireMergedPullRequestSource"], True)
 
-    def test_policy_rejects_versions_other_than_v130_rc4(self):
+    def test_policy_rejects_versions_other_than_v130_rc6(self):
         for version in (
             "v1.0.1",
             "v1.1.0",
@@ -84,15 +84,15 @@ class ReleasePolicyTest(unittest.TestCase):
             POLICY.check_public_ref(
                 self.policy,
                 "framework",
-                "v1.3.0-rc.5",
-                "v1.3.0-rc.5",
+                "v1.3.0-rc.6",
+                "v1.3.0-rc.6",
                 intent="qualify",
             )
 
     def test_policy_rejects_distribution_version_or_component_drift(self):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
-            ("  distributionVersion: v1.3.0-rc.5\n", "  distributionVersion: v1.3.1\n"),
+            ("  distributionVersion: v1.3.0-rc.6\n", "  distributionVersion: v1.3.1\n"),
             (
                 '  distributionComponents: "root,framework,admin,frontend"\n',
                 '  distributionComponents: "root,framework,frontend"\n',
@@ -110,7 +110,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         replacements = (
             ("  publicPrereleases: true\n", "  publicPrereleases: false\n"),
-            ("  nextPublicVersion: v1.3.0-rc.5\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
+            ("  nextPublicVersion: v1.3.0-rc.6\n", "  nextPublicVersion: v1.3.0-rc.01\n"),
             ("  currentStableVersion: v1.2.3\n", "  currentStableVersion: v1.2.3-rc.1\n"),
         )
         for old, new in replacements:
@@ -120,7 +120,7 @@ class ReleasePolicyTest(unittest.TestCase):
                     content = original.replace(old, new)
                     if "nextPublicVersion" in new:
                         content = content.replace(
-                            "  distributionVersion: v1.3.0-rc.5\n",
+                            "  distributionVersion: v1.3.0-rc.6\n",
                             "  distributionVersion: v1.3.0-rc.01\n",
                         )
                     candidate.write_text(content, encoding="utf-8")
@@ -131,7 +131,7 @@ class ReleasePolicyTest(unittest.TestCase):
         original = POLICY_PATH.read_text(encoding="utf-8")
         for suffix in (
             "  unexpected: true\n",
-            "  nextPublicVersion: v1.3.0-rc.5\n",
+            "  nextPublicVersion: v1.3.0-rc.6\n",
         ):
             with self.subTest(suffix=suffix.strip()):
                 with tempfile.TemporaryDirectory() as directory:

--- a/tools/release/test_release_phase_evidence.py
+++ b/tools/release/test_release_phase_evidence.py
@@ -214,7 +214,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
             EVIDENCE.validate_binding(
                 root,
                 policy_path=policy,
-                target_version="v1.3.0-rc.5",
+                target_version="v1.3.0-rc.6",
                 commit=commit,
                 require_clean=True,
             )
@@ -223,7 +223,7 @@ class ReleasePhaseEvidenceTest(unittest.TestCase):
                 EVIDENCE.validate_binding(
                     root,
                     policy_path=policy,
-                    target_version="v1.3.0-rc.5",
+                    target_version="v1.3.0-rc.6",
                     commit=commit,
                     require_clean=True,
                 )

--- a/tools/release/test_release_qualification_decision.py
+++ b/tools/release/test_release_qualification_decision.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 import release_qualification_decision as DECISION  # noqa: E402
 
 
-TARGET_VERSION = "v1.3.0-rc.5"
+TARGET_VERSION = "v1.3.0-rc.6"
 
 
 class ReleaseQualificationDecisionTest(unittest.TestCase):

--- a/tools/release/test_release_readiness_attestation.py
+++ b/tools/release/test_release_readiness_attestation.py
@@ -20,7 +20,7 @@ RUN_ID = 123456789
 RUN_URL = (
     "https://github.com/mss-boot-io/mss-boot-admin/actions/runs/123456789"
 )
-TARGET_VERSION = "v1.3.0-rc.5"
+TARGET_VERSION = "v1.3.0-rc.6"
 
 
 class ReleaseReadinessAttestationTest(unittest.TestCase):
@@ -50,7 +50,7 @@ class ReleaseReadinessAttestationTest(unittest.TestCase):
     def ready_policy(self, directory: str) -> Path:
         return self.policy_with_readiness(directory, True)
 
-    def test_checkpoint_attestation_binds_exact_v130_rc4_metadata(self):
+    def test_checkpoint_attestation_binds_exact_v130_rc6_metadata(self):
         attestation = self.checkpoint()
         self.assertEqual(set(attestation), ATTESTATION.REQUIRED_KEYS)
         self.assertEqual(attestation["schema"], ATTESTATION.SCHEMA)

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -112,7 +112,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             )
         )
 
-    def test_v130_rc4_feature_freeze_commands_are_exact_and_executable(self):
+    def test_v130_rc6_feature_freeze_commands_are_exact_and_executable(self):
         feature_path = (
             REPOSITORY_ROOT
             / ".mss"
@@ -148,6 +148,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             ". make web-v6-qualify",
             ". bash tools/compatibility/test-admin-external-consumer.sh",
             ". bash tools/compatibility/test-thin-host-external-consumer.sh",
+            ". go run ./cmd/mss eval run --all --format json",
         ):
             self.assertIn(required, commands)
 

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -89,11 +89,11 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         )
         self.assertEqual(self.step("Setup pnpm")["with"]["version"], "9.15.9")
 
-    def test_v130_rc4_qualification_selects_the_distribution_feature(self):
+    def test_v130_rc6_qualification_selects_the_distribution_feature(self):
         selected = PHASE_EVIDENCE.load_qualification(
             REPOSITORY_ROOT,
             Path(".mss/release-qualification.json"),
-            "v1.3.0-rc.5",
+            "v1.3.0-rc.6",
         )
         self.assertEqual(
             [path.relative_to(REPOSITORY_ROOT).as_posix() for path in selected],

--- a/web/antd-v6/CHANGELOG.md
+++ b/web/antd-v6/CHANGELOG.md
@@ -6,7 +6,7 @@ and the root changelog, not as a current release surface.
 
 ## Unreleased
 
-Target: **web/antd-v6/v1.3.0-rc.5**. The Admin Web package, Admin Go module,
+Target: **web/antd-v6/v1.3.0-rc.6**. The Admin Web package, Admin Go module,
 Framework module, and root distribution use one version core and one exact
 merged-main commit. Documentation remains an independently released component.
 
@@ -24,6 +24,8 @@ merged-main commit. Documentation remains an independently released component.
 
 ### Changed
 
+- Requalify the unchanged Admin Web runtime from the RC6 merged-main repair commit
+  so its package, image, and coordinated Go modules retain one source identity.
 - Enforce one installed React 19.2.8, React DOM 19.2.8, Ant Design 6.6.0,
   ProComponents 3.1.14-6, React Query 5.101.4, and Umi Max 4.7.5 runtime graph.
 - Remove the downstream-invisible pnpm patch dependency and keep the canonical


### PR DESCRIPTION
## Summary

- replace the obsolete copied-application file-count Eval with a bounded Thin Host contract (30..64 files)
- validate and test the new maximum bound so a future full-source copy also fails closed
- move the full Agent Eval into feature freeze before any coordinated release tag is created
- preserve immutable RC5 tags and advance the complete distribution train to v1.3.0-rc.6

## Root cause

The root tag workflow run https://github.com/mss-boot-io/mss-boot-admin/actions/runs/32360290204 failed only in the full Eval. The downstream application blueprint now intentionally generates a 31-file Thin Host, while the catalog still required at least 500 files from the retired source-copy architecture.

RC5 artifacts and tags are not moved or reused. This PR prepares a fresh RC6 from the next exact merged-main commit.

## Validation

- GOFLAGS=-mod=readonly go test -count=1 ./internal/mss/eval ./internal/mss/project ./internal/mss/blueprint
- 53 focused release-policy, phase-evidence, qualification, attestation, and readiness workflow tests
- feature specification validation and RC6 policy qualification for root/framework/admin/frontend
- exact failed CI step sequence, including full Agent Eval (all 6 cases pass)
- GOFLAGS=-mod=readonly go run ./cmd/mss verify --changed
- git diff --check origin/main...HEAD

## Docs impact

- update the complete Admin distribution ADR and coordinated changelogs to record the immutable RC5 failure and RC6 forward repair
- no user-facing installation or runtime behavior documentation changes are required

## Compatibility and security

- no runtime API, database, migration, or frontend behavior changes
- Thin Host lower bound preserves required managed composition files
- Thin Host upper bound prevents regressions to Foundation source copying
- full Eval now blocks feature freeze before public tags