### PR TITLE
docs(release): make v1.3.2 the stable baseline

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -179,7 +179,7 @@ jobs:
         if: ${{ inputs.phase == 'feature-freeze' || inputs.phase == 'pre-framework' || inputs.phase == 'pre-root' }}
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 9.15.9
+          version: 10.34.5
 
       - name: Setup Node
         if: ${{ inputs.phase == 'feature-freeze' || inputs.phase == 'pre-framework' || inputs.phase == 'pre-root' }}
@@ -193,12 +193,12 @@ jobs:
 
       - name: Install frontend dependencies
         if: ${{ inputs.phase == 'feature-freeze' || inputs.phase == 'pre-framework' || inputs.phase == 'pre-root' }}
-        run: corepack pnpm@10.34.5 --dir web/antd-v6 install --frozen-lockfile --ignore-scripts
+        run: pnpm --dir web/antd-v6 install --frozen-lockfile --ignore-scripts
 
       - name: Install Playwright Chromium
         if: ${{ inputs.phase == 'feature-freeze' || inputs.phase == 'pre-framework' || inputs.phase == 'pre-root' }}
         working-directory: web/antd-v6
-        run: corepack pnpm@10.34.5 exec playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Install documentation dependencies
         if: ${{ inputs.phase == 'feature-freeze' }}

--- a/.mss/capabilities.yaml
+++ b/.mss/capabilities.yaml
@@ -743,9 +743,10 @@ spec:
         permission and menu metadata, typed Ant Design 6 client/page/routes/locales, generated module
         documentation, and semantic browser E2E. The Supplier plan is complete with zero deferred
         projections and is exercised through repository-external Thin Host generation, build,
-        authorization, browser, upgrade, preservation, and two-run idempotency gates. Keep the
-        capability beta until stable v1.3.2 public consumption and a second representative domain
-        prove the schema without weakening deterministic or generated/custom ownership boundaries.
+        authorization, browser, upgrade, preservation, and two-run idempotency gates. Stable
+        v1.3.2 public Go and npm consumption is now proven. Keep the capability beta until a second
+        representative domain proves the schema without weakening deterministic or
+        generated/custom ownership boundaries.
 
     - id: foundation.admin-distribution
       displayName: Complete Admin Distribution and Thin Business Hosts
@@ -773,9 +774,11 @@ spec:
         consume them through coordinated versioned dependencies and add only compile-time modules and
         pages. The external Supplier host has passed GOWORK=off backend, local npm tarball,
         one-runtime, deterministic Thin Host generation and upgrade, authorization, and browser E2E
-        gates; v1.3.0-rc.6 is immutable successful preview evidence. The capability remains beta while
-        stable v1.3.2 Go resolution plus byte-identical npmjs and GitHub Packages resolution and
-        post-publication reconciliation are pending.
+        gates; v1.3.0-rc.6 is immutable successful preview evidence. Stable v1.3.2 Go resolution,
+        byte-identical npmjs and GitHub Packages resolution, and post-publication reconciliation
+        have completed. The released distribution is stable; the capability remains beta until a
+        second representative domain and a later stable-to-stable Thin Host upgrade prove the
+        extension and upgrade boundaries again.
         Do not add runtime plugins, micro-frontends, core feature selection, telemetry, import records,
         or adopter registration.
 
@@ -879,19 +882,14 @@ spec:
       guidance: >-
         Treat Unreleased, planned, preview, branches, and local workspace replacements as non-stable.
         Published historical versions remain immutable and their candidate evidence is not reusable.
-        The active reviewed target is stable v1.3.2 for root, Framework, the importable Admin module,
-        and the sole Ant Design V6 frontend. RC6 plus the incomplete v1.3.0 and v1.3.1 publication
-        attempts remain immutable historical evidence; every other alpha, beta, RC, or stable tag
-        remains forbidden. Complete release readiness begins only after one v1.3.2 feature-freeze commit already
-        merged into main is selected. An emergency
-        patch requires a reviewed policy target change rather than a bypass.
-        Publish Framework first, then the importable Admin module, the complete frontend GitHub Packages
-        mirror, root, and the independently releasable Docs component from the same reviewed commit;
-        publish the byte-identical frontend tarball to official npm as the final artifact publication.
-        Finalize a stable release only after migrations, security checks, versioned artifacts, containers,
-        documentation, installation smoke tests, and
-        recovery evidence pass. This governance remains beta until post-release truth reconciliation,
-        deterministic Foundation release/Blueprint/generator/downstream-snapshot identity with atomic
-        lock and manifest records, and drift checks are enforced. Keep
-        .mss/lock.yaml on its real development/generated baseline until that process records the exact
-        published foundation version and commit.
+        The current stable release is v1.3.2 for root, Framework, the importable Admin module, and
+        the sole Ant Design V6 frontend. Its ordered Framework, Admin, frontend, root, Docs, and
+        official npm train plus public reconciliation completed from exact merged-main commit
+        635fbb03a82976941e527d8ac1000fec0624abac. RC6 and the incomplete v1.3.0 and v1.3.1
+        publication attempts remain immutable historical evidence. Any emergency patch requires a
+        reviewed policy target change, a new merged-main commit, and rerun affected gates rather
+        than a bypass. This governance remains beta because deterministic Foundation
+        release/Blueprint/generator/downstream-snapshot identity with atomic lock and manifest
+        records plus automated drift checks are not yet fully enforced. Keep .mss/lock.yaml honest:
+        its distribution entries record v1.3.2 while development/generated Foundation and Blueprint
+        baselines remain explicit until a later snapshot process records a published identity.

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -286,8 +286,8 @@ spec:
       idempotent: true
 
     official-npm-publish:
-      command: gh workflow run npm-release.yml --ref <root-tag> -f version=v1.3.2 -f commit=<full-sha> -f allow_npm_token_bootstrap=<true|false>
-      description: As the final artifact publication, publish the already-qualified Admin Web GitHub Release tarball to public npmjs from the exact root tag; use the protected bootstrap token only for the first package version, then rely on Trusted Publishing.
+      command: gh workflow run npm-release.yml --ref <root-tag> -f version=v1.3.2 -f commit=<full-sha> -f allow_npm_token_bootstrap=false
+      description: As the final artifact publication, publish the already-qualified Admin Web GitHub Release tarball to public npmjs from the exact root tag through the bound npm Trusted Publisher; the completed one-time bootstrap path is historical and future runs fail closed without matching OIDC identity.
       outputFormats: [text]
       category: release
 

--- a/.mss/features/complete-admin-distribution-thin-host.yaml
+++ b/.mss/features/complete-admin-distribution-thin-host.yaml
@@ -157,7 +157,7 @@ spec:
         - The nested Admin Go module uses admin/vX.Y.Z and all coordinated artifacts share the same exact semantic version, including prerelease identifiers.
         - Frontend qualification includes pack contents, integrity, SBOM, GitHub provenance attestation, and fail-closed credential handling.
         - Admin Web publishes first to GitHub Packages under the repository-linked @mss-boot-io scope; Thin Hosts authenticate without committing a token.
-        - The v1.3.0-rc.6 train is a prerelease and does not replace the current v1.2.3 stable release.
+        - At RC6 publication time, the prerelease did not replace v1.2.3; RC6 remains immutable preview evidence and v1.3.2 is now the reconciled current stable release.
         - >-
           The immutable v1.3.0-rc.1 train remains partial evidence: Framework, Admin, and the
           frontend image published, while the frontend package, frontend GitHub Release, and root

--- a/.mss/features/foundation-v1-3-2-release.yaml
+++ b/.mss/features/foundation-v1-3-2-release.yaml
@@ -127,7 +127,7 @@ spec:
       statement: npmjs publication is the final artifact mutation and reuses the already-qualified frontend Release tarball without rebuilding.
     - id: protected-credentials
       type: security
-      statement: Qualification uses no production secret; the GitHub bootstrap secret is removed after initial npmjs publication, future publication fails closed until Trusted Publishing is bound, and the npm-side bootstrap token is then revoked.
+      statement: Qualification uses no production secret; the one-time GitHub bootstrap secret was removed after initial npmjs publication, npm Trusted Publishing is bound to mss-boot-io/mss-boot-admin npm-release.yml in release-v6 with only npm publish allowed, and the npm-side bootstrap token is revoked. Future publication uses matching OIDC identity and fails closed otherwise.
   acceptance:
     - id: checkpoint-v132-contract
       requirement: target-v132-only
@@ -272,9 +272,9 @@ spec:
       severity: critical
       mitigation: Calculate from every tracked final Framework file at checkpoint and pre-framework, and bind all readiness evidence to one immutable merged-main tree.
     - id: bootstrap-credential
-      description: The first npmjs publication requires a temporary write credential before Trusted Publishing can be bound.
+      description: The first npmjs publication required a temporary write credential before Trusted Publishing could be bound; retaining it afterward would create unnecessary persistent access.
       severity: high
-      mitigation: Keep it only in release-v6, use it once with explicit bootstrap input, then bind OIDC and revoke and remove the token immediately.
+      mitigation: The credential was used once, the GitHub secret was removed, OIDC was bound to the exact workflow and environment, and the npm-side token was revoked. Future publication has no token fallback.
     - id: database-rollback
       description: A binary rollback without its matching data backup can leave an incompatible authorization or schema projection.
       severity: critical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,21 +16,25 @@ Status: **published / current stable**. Root, `mss-boot/v1.3.2`,
 commit `635fbb03a82976941e527d8ac1000fec0624abac`. Public checksums, npm provenance,
 multi-architecture image digests, Docs identity, and immutable Release assets are
 indexed in [issue #519](https://github.com/mss-boot-io/mss-boot-admin/issues/519).
+The public npm `latest` tag resolves to `1.3.2`; npm Trusted Publishing is bound
+to repository `mss-boot-io/mss-boot-admin`, workflow `npm-release.yml`, and
+environment `release-v6`. The one-time bootstrap npm token plus GitHub
+`NPM_TOKEN` secret have been removed.
 
 The v1.3.1 train is immutable component-partial history. Framework
 `mss-boot/v1.3.1` was published from
 `4830fee162326788732e476a04d24f47b8fd570a`. The `admin/v1.3.1` tag points to
 the same commit, but its workflow stopped before creating an Admin Release when
 the committed Framework Module sum differed from the canonical public module.
-No v1.3.1 root, Admin Web, Docs, or npmjs release completed. The repair uses a
-new v1.3.2 patch and never moves or reuses those identities.
+No v1.3.1 root, Admin Web, Docs, or npmjs release completed. The repair used a
+new v1.3.2 patch and never moved or reused those identities.
 
 The v1.3.0 train is immutable component-partial history. Framework
 `mss-boot/v1.3.0` was published from
 `76530526e436eb95652df1dd06e831a90ee73125`, while the Admin workflow stopped
 after creating `admin/v1.3.0` because the independent module metadata lacked the
 published Framework checksums. No v1.3.0 root, Admin Web, Docs, or npmjs release
-completed. Those identities are not moved or reused by this v1.3.2 target.
+completed. Those identities were not moved or reused by the v1.3.2 release.
 
 The complete v1.3.0-rc.6 preview train was published successfully from
 `0ef09fb3caa1b2d424c540da23d01219135ebcfa`. Its Framework and Admin modules,
@@ -131,7 +135,7 @@ Status: **component-partial / immutable**. Framework and the sole V6 frontend
 were published from `29a99f2bdb9a2c516459529918795404c153df2e`. Root candidate
 qualification passed and the root tag was created, but the multi-architecture
 image publish timed out after the arm64 QEMU build; no root image or GitHub
-Release was completed. v1.2.3 is the only active forward-repair target.
+Release was completed. The next complete coordinated train was v1.2.3.
 
 ### Changed
 
@@ -159,8 +163,8 @@ Status: **component-partial / immutable**. Framework and the sole V6 frontend we
 published from `80d2d20f1b44105e18706cfa0deb7f8512966f92`. The root tag and runtime
 image were created, but root package assembly and GitHub Release publication did
 not complete because the root workflow still uploaded raw V6 output. v1.2.2
-repaired that artifact path but later stopped at root image publication; v1.2.3
-is the only active forward-repair target.
+repaired that artifact path but later stopped at root image publication; the next
+complete coordinated train was v1.2.3.
 
 ### Changed
 
@@ -204,7 +208,8 @@ is the only active forward-repair target.
 ## [v1.1.0] - 2026-08-11
 
 Status: **published / historical**. This section is retained as immutable release
-history; all active release preparation now targets v1.2.3.
+history. The next complete coordinated train was v1.2.3; the current stable train
+is v1.3.2.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ machine-readable project contracts, deterministic full-stack generation,
 change-aware verification, and upgradeable Thin Host Blueprints in one source
 repository.
 
-The active stable target is **v1.3.2**. Formal publication qualifies it as one
-Complete Admin Distribution from one exact merged `main` commit. The published
+The current stable release is **v1.3.2**, published as one Complete Admin
+Distribution from exact merged `main` commit
+`635fbb03a82976941e527d8ac1000fec0624abac`. The published
 `mss-boot/v1.3.1` Framework release and failed `admin/v1.3.1` qualification are
 permanently immutable partial-train history; they cannot substitute for or be
 moved into the complete v1.3.2 artifacts.
@@ -53,8 +54,8 @@ business intent
 
 ## Consume v1.3.2
 
-After the stable tags are public, Go consumers should pin the exact coordinated
-version. The Admin module has no committed local `replace`:
+The stable tags are public. Go consumers should pin the exact coordinated
+version; the Admin module has no committed local `replace`:
 
 ```shell
 go get github.com/mss-boot-io/mss-boot-admin/mss-boot@v1.3.2
@@ -76,6 +77,10 @@ Stable packages receive the `latest` distribution tag. Prereleases receive
 `next`; generated Thin Hosts still pin an exact version rather than a moving
 tag. The official npm publication is the final artifact publication, after all
 coordinated component and Docs releases resolve to the same merged-main commit.
+For v1.3.2, npm `latest` resolves to `1.3.2`; future publication uses npm Trusted
+Publishing bound to `mss-boot-io/mss-boot-admin`, `npm-release.yml`, and the
+`release-v6` environment. No bootstrap npm token or GitHub `NPM_TOKEN` secret
+remains.
 
 ## Create and upgrade a Thin Host
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,8 +10,9 @@
 整合了面向生产的 Go Admin、React 19 + Ant Design 6 应用、机器可读项目契约、
 确定性全栈生成、变更感知验证和可持续升级的 Thin Host Blueprint。
 
-当前稳定版目标是 **v1.3.2**。正式发布前，完整 Admin 发行包必须从同一个已合并
-`main` 提交完成资格验证。已公开的 `mss-boot/v1.3.1` 与失败的 `admin/v1.3.1`
+当前稳定版是 **v1.3.2**，已从精确 merged-main 提交
+`635fbb03a82976941e527d8ac1000fec0624abac` 完整发布并完成公开对账。已公开的
+`mss-boot/v1.3.1` 与失败的 `admin/v1.3.1`
 资格验证属于永久不可变的部分发布历史；它们不能替代或移动为完整 v1.3.2 制品。
 
 ## 完整 Admin 发行包
@@ -45,7 +46,7 @@ AdminModule 契约描述，并在开发期确定性生成。
 
 ## 引用 v1.3.2
 
-稳定版标签公开后，Go 使用方应锁定完全一致的版本。Admin Module 不包含本地
+稳定版标签已经公开。Go 使用方应锁定完全一致的版本；Admin Module 不包含本地
 `replace`：
 
 ```shell
@@ -64,8 +65,10 @@ GitHub Packages 保留完全相同的不可变 tarball 作为兼容镜像。只�
 
 稳定包使用 `latest` 分发标签，预发布包使用 `next`。生成的 Thin Host 仍会锁定精确
 版本，而不会依赖移动标签。官方 npm 发布是最后一次制品发布，必须等所有协调组件和
-Docs Release 都解析到同一个 merged-main 提交后才执行；之后只允许只读对账、安装验证，
-以及首次发布所需的一次 Trusted Publisher 绑定与临时 Token 撤销。
+Docs Release 都解析到同一个 merged-main 提交后才执行。v1.3.2 的 npm `latest` 已指向
+`1.3.2`；后续发布通过绑定 `mss-boot-io/mss-boot-admin`、`npm-release.yml` 与
+`release-v6` 的 npm Trusted Publishing 完成，不再保留 bootstrap npm Token 或 GitHub
+`NPM_TOKEN` Secret。
 
 ## 创建与升级 Thin Host
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,10 @@ private GitHub advisories are the preferred intake path.
 ## Supported versions
 
 The active `main` branch and the current stable Complete Admin Distribution are
-supported by default. During v1.3.2 preparation the reconciled stable remains
-v1.2.3; after all v1.3.2 public artifacts and the follow-up reconciliation are
-complete, the machine-readable policy advances the stable line to v1.3.2.
+supported by default. The current stable line is v1.3.2 at release commit
+`635fbb03a82976941e527d8ac1000fec0624abac`; v1.2.3 is retained as the
+previous-stable coordinated rollback baseline, not as the default supported
+line.
 Preview and release-candidate refs remain immutable evidence but do not receive
 the stable support commitment. Older stable versions are handled case by case.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 
 - 当前稳定版：`v1.3.2`，精确发布提交为 `635fbb03a82976941e527d8ac1000fec0624abac`。
 - 上一稳定版：`v1.2.3`，保留为协调回滚基线和历史证据。
+- npm `latest`：`@mss-boot-io/admin-web@1.3.2`；发布身份已切换到精确绑定的 Trusted Publishing OIDC，bootstrap Token 与 GitHub Secret 均已撤销。
 - `mss-boot/v1.3.0` 已公开、`admin/v1.3.0` 发布失败；该不完整列车永久保留且不复用。
 - `v1.3.0-rc.1` 至 `v1.3.0-rc.6` 是不可变的预览证据，不移动、不覆盖、不复用。
 - Docs 可以用 `docs/vX.Y.Z` 独立发布，但只能来自已合并到 `main` 的精确提交。
@@ -61,7 +62,7 @@ corepack pnpm@9.15.9 --dir docs build
 go run ./cmd/mss verify --changed
 ```
 
-发布准备 PR 还需要使用 Codex 内置浏览器检查首页、Admin、发布页、导航、深色主题和窄屏布局。
+后续发布准备 PR 还需要使用 Codex 内置浏览器检查首页、Admin、发布页、导航、深色主题和窄屏布局。
 构建成功只证明静态产物可生成，不代替视觉检查或公开站点发布证据。
 
 ## 贡献

--- a/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
+++ b/docs/adr/2026-08-19-complete-admin-distribution-and-thin-business-host.md
@@ -1,6 +1,6 @@
 # ADR: Complete Admin distribution and thin business hosts
 
-- Status: Accepted and implemented; v1.3.0-rc.6 published successfully, v1.3.0 and v1.3.1 are immutable component-partial history, and v1.3.2 is the active stable target
+- Status: Accepted and implemented; v1.3.0-rc.6 published successfully, v1.3.0 and v1.3.1 are immutable component-partial history, and v1.3.2 is the current stable release from `635fbb03a82976941e527d8ac1000fec0624abac`
 - Date: 2026-08-19
 - Owners: Admin, frontend, agent infrastructure, release engineering
 - Feature contract: `.mss/features/complete-admin-distribution-thin-host.yaml`
@@ -43,9 +43,11 @@ package artifact.
 Official npm publication does not rebuild the frontend. A protected final workflow downloads the tarball,
 evidence, SBOM, and checksums from the exact frontend GitHub Release, verifies every coordinated tag and
 Release against the frozen commit, then publishes that same tarball to npmjs as the final artifact
-publication. The first package publication uses a short-lived protected bootstrap credential; after
-that package exists, one security-only handoff binds npm Trusted Publishing OIDC to the exact workflow
-and `release-v6` environment and revokes the bootstrap credential. Subsequent versions use OIDC.
+publication. The v1.3.2 first package publication used a short-lived protected bootstrap credential;
+the completed security handoff then bound npm Trusted Publishing OIDC to
+`mss-boot-io/mss-boot-admin`, `npm-release.yml`, and `release-v6` with only `npm publish` allowed,
+removed the GitHub secret, and revoked the npm-side token. Subsequent versions use OIDC with no token
+fallback.
 
 `management-system` becomes the single recommended thin-host Blueprint. It generates application glue,
 business source directories, machine contracts, deployment files, and CI while depending on the
@@ -95,12 +97,13 @@ business files, and records a thin baseline only after all file operations and v
 
 Technical artifacts may use root, `mss-boot/`, `admin/`, and `web/antd-v6/` tag namespaces, but their
 exact semantic version, including a prerelease suffix, must match for a coordinated distribution. The
-successful public preview is `v1.3.0-rc.6`; it is immutable and does not replace the current `v1.2.3`
-stable release. The `v1.3.0` train is also immutable component-partial history: Framework published,
-Admin failed before publication, and the remaining stable artifacts were not created. The only active
-target is now `v1.3.2` stable. Publication remains restricted to a new
-exact merged-main commit and the protected Framework -> Admin -> Frontend -> Root -> Docs -> npmjs
-release train; the final npmjs step republishes the already-qualified frontend tarball without rebuilding.
+successful public preview is `v1.3.0-rc.6`; at publication time it did not replace v1.2.3 and it remains
+immutable preview evidence. The `v1.3.0` and `v1.3.1` trains are immutable component-partial history.
+The coordinated `v1.3.2` train completed through the protected Framework -> Admin -> Frontend -> Root ->
+Docs -> npmjs sequence from exact merged-main commit
+`635fbb03a82976941e527d8ac1000fec0624abac` and is now the current stable release. Any later release
+remains restricted to a new exact merged-main commit; the final npmjs step republishes the already
+qualified frontend tarball without rebuilding.
 
 The immutable `v1.3.0-rc.1` train remains partial evidence. Framework, Admin, and the multi-architecture
 frontend image published, but a workflow verifier defect stopped the frontend package and GitHub Release;
@@ -158,11 +161,12 @@ Downstream repositories become substantially smaller and upgrades operate on thi
 product sources. In exchange, the complete Admin application entrypoint, business module API, frontend
 exports, and coordinated version become compatibility surfaces that require external-consumer gates.
 
-The implementation and RC6 preview have passed the repository-external Supplier host gate: GOWORK=off backend validation,
-tarball frontend validation, single-runtime analysis, deterministic generation and upgrade tests, and the
-required browser E2E described by the Feature contract. The incomplete v1.3.0 stable attempt remains
-audit evidence only and must not be continued. v1.3.2 publication remains separately gated on
-the preparation PR merge, a new exact merged-main commit, remote qualification, and coordinated immutable artifacts.
+The implementation, RC6 preview, and stable v1.3.2 release have passed the repository-external Supplier
+host gate: GOWORK=off backend validation, public Go and npm consumption, single-runtime analysis,
+deterministic generation and upgrade tests, and the required browser E2E described by the Feature
+contract. The incomplete v1.3.0 and v1.3.1 attempts remain audit evidence only and must not be
+continued. The next measurable maturity step is to repeat the full specification, generation, external
+Thin Host, upgrade-preservation, and browser path with a second representative business domain.
 
 Because the npm package deliberately carries package-owned build tools for thin hosts, its distribution
 metadata partitions every published dependency into runtime or tooling roots. Runtime security findings

--- a/docs/docs/admin/current-capabilities.md
+++ b/docs/docs/admin/current-capabilities.md
@@ -134,7 +134,7 @@ Supplier 是示例和回归契约，不把采购领域能力移动到领域中�
 - 菜单可见性取决于迁移、API 同步、角色授权和当前 Session；
 - 可选集成取决于真实配置和外部服务；
 - Admin、Framework、Admin Web 必须使用同一个协调版本；
-- npmjs 是 Admin Web 默认公开安装源，不需要 Registry Token；GitHub Packages 仅作为完全相同制品的兼容镜像，选择镜像时 Token 不能写入仓库；
+- npmjs 是 Admin Web 默认公开安装源，不需要 Registry Token；`latest` 已指向 `1.3.2`，发布端使用绑定 `npm-release.yml` 与 `release-v6` 的 Trusted Publishing OIDC；GitHub Packages 仅作为完全相同制品的兼容镜像，选择镜像时 Token 不能写入仓库；
 - 生产升级先备份并验证恢复，再迁移、同步 API、启动和切流；
 - 回滚恢复上一组协调制品及其数据库备份，不临时 down migration。
 

--- a/docs/docs/admin/docker.md
+++ b/docs/docs/admin/docker.md
@@ -25,9 +25,9 @@ keywords: [admin docker deploy nginx production]
 - 已确认生产环境不暴露上传入口；Local/S3-compatible 当前仍为 Legacy / Blocked
 - 若启用 WebSocket 集群或缓存，已准备 Redis
 
-下列命令固定使用 `v1.3.2`，仅在该稳定版本正式发布后执行。发布前资格验证应使用
-同一冻结提交在受控流程中构建的候选制品；生产部署还应记录并固定验证过的镜像
-digest，绝不能依赖 `latest`。
+下列命令固定使用已发布并完成公开对账的当前稳定版 `v1.3.2`。生产部署还应记录并
+固定验证过的镜像 digest，绝不能依赖 `latest`；未来候选的资格验证仍必须使用同一
+冻结提交在受控流程中构建的候选制品。
 
 ## 推荐目录约定
 

--- a/docs/docs/admin/pre-release-checklist.md
+++ b/docs/docs/admin/pre-release-checklist.md
@@ -12,7 +12,7 @@ keywords: [admin release checklist production deployment]
 
 :::warning
 本文是 2026-04 的历史记录，下面的勾选项、版本号、命令和结论不能用于当前发布。
-当前唯一活动目标及可执行门禁见 [发布与升级](/releases)及
+当前稳定基线及后续版本的可执行门禁见 [发布与升级](/releases)及
 [v1.3.2 发布合同](/releases/v1-3-2)；缺少任一 required 精确 SHA 证据时结论均为
 **NO-GO**。
 :::

--- a/docs/docs/admin/theme-settings-precedence.md
+++ b/docs/docs/admin/theme-settings-precedence.md
@@ -14,7 +14,7 @@ keywords: [admin ant-design-v6 theme settings precedence inheritance]
 - 前端：仅 `web/antd-v6`
 - 机器契约：`.mss/features/admin-theme-settings-precedence.yaml`
 - 切换决策：`docs/adr/2026-08-17-ant-design-v6-default-cutover.md`
-- 状态：实现已接入，发布前仍需完成集中测试、三数据库升级验证和浏览器验收
+- 状态：实现已接入，并已在 v1.3.2 冻结提交上完成集中测试、SQLite/MySQL/PostgreSQL 升级验证和 Codex 内置浏览器验收；能力成熟度仍以 `.mss/capabilities.yaml` 为准
 
 本页只描述 V6 规范契约。后端不再返回旧主题投影，不接受缺少修订号的写入，
 前端也不会从 V5 的本地存储键、媒体类型或无版本响应中恢复状态。

--- a/docs/docs/architecture/agent-native-foundation.zh-CN.md
+++ b/docs/docs/architecture/agent-native-foundation.zh-CN.md
@@ -25,8 +25,9 @@ keywords: [agent native codex infrastructure generator mcp skills eval]
 - P0–P7 的顶层契约、`mss` CLI、AdminModule 生成、Skills、MCP、Evals、Thin Host Blueprint
   和升级引擎已经落地；具体成熟度以 `.mss/capabilities.yaml` 为准。
 - Supplier 已作为完整前后端生成和外部 Thin Host 黄金样例。
-- `v1.3.0-rc.6` 已完成协调预览发布；`v1.3.1` 是不可变的部分发布历史，唯一活动目标为 `v1.3.2` stable，当前稳定版仍是
-  `v1.2.3`。
+- `v1.3.0-rc.6` 已完成协调预览发布；`v1.3.1` 是不可变的部分发布历史；`v1.3.2`
+  已从精确 merged-main 提交 `635fbb03a82976941e527d8ac1000fec0624abac` 完整发布并完成
+  公开对账，现为当前稳定版，`v1.2.3` 保留为上一稳定版和协调回滚基线。
 - P8 的既有横向 Admin 模块不会机械式整体迁移；新业务默认使用 `admin/modules/<name>`，
   老路径保持兼容维护。
 
@@ -630,7 +631,7 @@ Token 消耗
 
 ## 18. 当前实施基线
 
-截至 `v1.3.2` stable 准备，仓库已经形成以下可执行闭环：
+截至 `v1.3.2` stable 完整发布和公开对账，仓库已经形成以下可执行闭环：
 
 1. 顶层 `AGENTS.md` 与 `.mss/` 提供人机共享事实源。
 2. `mss context`、`doctor`、`setup`、`dev`、`verify`、`eval`、`new app` 和 `upgrade`
@@ -640,7 +641,10 @@ Token 消耗
 5. `management-system` Blueprint 生成 31 个受管文件的 Thin Host，并通过二次幂等和外部消费者门禁。
 6. MCP 保持 CLI 的薄适配层，写操作默认 dry-run。
 7. RC6 已从一个精确 merged-main 提交完成 Framework、Admin、Admin Web 和 Root 预览列车。
+8. v1.3.2 已完成 Framework、Admin、Admin Web、Root、Docs、官方 npm 的协调发布，公共
+   Go/npm 解析、镜像、provenance、文档身份和 Trusted Publishing 均已对账。
 
-下一条可执行步骤是通过 Pull Request 合并 stable 准备，冻结新的精确 `main` 提交，重跑
-checkpoint、feature-freeze、外部 Thin Host、三数据库/API 注册表和内置浏览器证据，再发布
-`v1.3.2`。P8 继续采用按真实需求逐模块迁移，而不是一次性重写既有横向实现。
+下一条可执行步骤是选择第二个代表性业务域，提交结构化 AdminModule 规格，在仓库外 Thin
+Host 上完成两次生成零漂移、`GOWORK=off` 后端、精确 npm 安装、升级保留和浏览器 E2E，验证
+现有生成与扩展边界不只适用于 Supplier。P8 继续采用按真实需求逐模块迁移，而不是一次性
+重写既有横向实现。

--- a/docs/docs/architecture/complete-admin-distribution-and-thin-business-host.zh-CN.md
+++ b/docs/docs/architecture/complete-admin-distribution-and-thin-business-host.zh-CN.md
@@ -697,11 +697,12 @@ Agent 不应编辑：
 test、单一生产 `dist`/Runtime 和浏览器 E2E。标准 Admin 通过 Codex 内置浏览器验证登录、
 工作台、菜单 API 绑定、Supplier、硬刷新、403、深色主题和控制台健康。
 
-`v1.3.0-rc.6` 已完成一列协调预览发布，证明发布拓扑可用，但它不替代当前 `v1.2.3`
-stable。下一条可执行步骤是把 stable 准备变更通过 Pull Request 合并到 `main`，从新的精确
-提交重新执行 checkpoint、feature-freeze、三数据库/API 注册表、内置浏览器和外部消费者
-资格，再按 Framework → Admin → Frontend → Root 顺序发布。topic branch 不创建 Tag、Release、
-镜像或 npm package。
+`v1.3.0-rc.6` 已完成协调预览；`v1.3.2` 随后从精确 merged-main 提交
+`635fbb03a82976941e527d8ac1000fec0624abac` 完成 Framework → Admin → Frontend → Root →
+Docs → 官方 npm 的协调发布、外部消费者验证和公开对账，现为当前 stable。下一条可执行步骤
+是用第二个代表性业务域重跑规格、两次生成零漂移、仓库外 Thin Host、升级保留和浏览器 E2E，
+以验证扩展边界的通用性。未来任何修复仍必须先经 Pull Request 合并到 `main`；topic branch
+不创建 Tag、Release、镜像或 npm package。
 
 ### 阶段一：设计与契约
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -37,6 +37,7 @@ features:
 | --- | --- |
 | 当前稳定版 | `v1.3.2`，提交 `635fbb03a82976941e527d8ac1000fec0624abac` |
 | 上一稳定版 | `v1.2.3`，协调回滚基线 |
+| Admin Web 公开安装 | npm `latest=1.3.2`；后续发布使用 `release-v6` Trusted Publishing OIDC |
 | 不完整稳定列车 | Framework `v1.3.0` 已公开；Admin 发布失败，其余稳定组件未发布 |
 | 已完成预览 | `v1.3.0-rc.6` 完整列车；RC1–RC6 保持不可变 |
 | 前端主线 | `web/antd-v6`；Ant Design 5 已退役 |

--- a/docs/docs/operations/admin-distribution-v1.3.0-rc.4.zh-CN.md
+++ b/docs/docs/operations/admin-distribution-v1.3.0-rc.4.zh-CN.md
@@ -5,12 +5,13 @@ order: 35
 
 # Admin Distribution v1.3.0-rc.4 预览版引用
 
-`v1.3.0-rc.4` 是完整 Admin Distribution 的公开预览版，不替代当前
-`v1.2.3` 稳定版。Root、Framework、Admin Go Module 与 Admin Web 使用同一个
-精确版本，并从同一个已合并到 `main` 的提交发布。
+`v1.3.0-rc.4` 是完整 Admin Distribution 的公开预览版；在其发布时并未替代
+`v1.2.3` 稳定版。当前稳定版已推进到 [v1.3.2](/releases/v1-3-2)。Root、Framework、
+Admin Go Module 与 Admin Web 使用同一个精确版本，并从同一个已合并到 `main` 的提交发布。
 
 > RC4 现为不可变历史预览记录。Framework、Admin 与前端制品已公开，Root 标签已创建但
-> Root GitHub Release 未完成；当前前向修复目标为 [v1.3.0-rc.5](./admin-distribution-v1.3.0-rc.5.zh-CN.md)。
+> Root GitHub Release 未完成；当时的下一前向修复为
+> [v1.3.0-rc.5](./admin-distribution-v1.3.0-rc.5.zh-CN.md)。
 
 对应制品如下：
 

--- a/docs/docs/operations/admin-distribution-v1.3.0-rc.5.zh-CN.md
+++ b/docs/docs/operations/admin-distribution-v1.3.0-rc.5.zh-CN.md
@@ -5,9 +5,9 @@ order: 34
 
 # Admin Distribution v1.3.0-rc.5 预览版引用
 
-`v1.3.0-rc.5` 是完整 Admin Distribution 的公开预览版，不替代当前
-`v1.2.3` 稳定版。Root、Framework、Admin Go Module 与 Admin Web 必须使用同一精确版本，
-并从同一个已合并到 `main` 的提交发布。
+`v1.3.0-rc.5` 是完整 Admin Distribution 的公开预览版；在其发布时并未替代
+`v1.2.3` 稳定版。当前稳定版已推进到 [v1.3.2](/releases/v1-3-2)。Root、Framework、
+Admin Go Module 与 Admin Web 必须使用同一精确版本，并从同一个已合并到 `main` 的提交发布。
 
 | 组件 | 引用 |
 | --- | --- |

--- a/docs/docs/releases/index.md
+++ b/docs/docs/releases/index.md
@@ -56,7 +56,10 @@ Framework 跟踪文件生成 replace-free 本地 Go Proxy，由 Go 计算规范 
 3. 按 Framework → Admin → Admin Web → Root → Docs → 官方 npm 顺序公开；
 4. 公开 Go Module、npm integrity/provenance、镜像 digest/架构、Release 资产与
    <code>latest</code> 均完成只读对账；
-5. 机器契约将 <code>v1.3.2</code> 与精确发布提交记录为 current stable。
+5. npm Trusted Publisher 已精确绑定 <code>mss-boot-io/mss-boot-admin</code>、
+   <code>npm-release.yml</code> 和 <code>release-v6</code>，且只允许 <code>npm publish</code>；
+   bootstrap npm Token 与 GitHub <code>NPM_TOKEN</code> Secret 均已撤销；
+6. 机器契约将 <code>v1.3.2</code> 与精确发布提交记录为 current stable。
 
 完整操作见 [v1.3.2 发布、安装、升级与回滚合同](/releases/v1-3-2)，证据索引见
 [GitHub issue #519](https://github.com/mss-boot-io/mss-boot-admin/issues/519)。

--- a/docs/docs/releases/v1-2-0.md
+++ b/docs/docs/releases/v1-2-0.md
@@ -10,7 +10,8 @@ keywords: [v1.2.0 release upgrade migration antd-v6 api registry rollback]
 
 # v1.2.0 发布合同
 
-当前状态：**component-partial / 先由 v1.2.1、v1.2.2 接续，当前活动目标为 v1.2.3**。
+当前状态：**component-partial / 先由 v1.2.1、v1.2.2 接续，随后由 v1.2.3 完成修复**。
+当前稳定版为 [v1.3.2](/releases/v1-3-2)；v1.2.3 仅保留为上一稳定回滚基线。
 
 `mss-boot/v1.2.0` 已从提交 `c0b4b4d7888a67931951f0b40198d98614e979af`
 成功发布并完成外部代理解析。`web/antd-v6/v1.2.0` 标签指向同一提交，但发布工作流在
@@ -18,7 +19,7 @@ keywords: [v1.2.0 release upgrade migration antd-v6 api registry rollback]
 GitHub Release。根 `v1.2.0` 标签从未创建。
 
 所有 v1.2.0 标签和证据保持不可变，不移动、不复用、不补发。以下保留原始范围与门禁
-作为审计记录；当前唯一活动目标与后续步骤见 [v1.2.3 发布合同](/releases/v1-2-3)。
+作为审计记录；当时的完整前向修复见 [v1.2.3 发布合同](/releases/v1-2-3)。
 
 原定同步列车要求根仓库、可复用 Framework 和唯一的 Ant Design V6 前端来自同一个
 已合并到 `origin/main` 的精确提交：

--- a/docs/docs/releases/v1-2-1.md
+++ b/docs/docs/releases/v1-2-1.md
@@ -10,12 +10,13 @@ keywords: [v1.2.1 release forward repair migration antd-v6 api registry rollback
 
 # v1.2.1 发布合同
 
-当前状态：**component-partial / 先由 v1.2.2 接续，当前活动目标为 v1.2.3**。
+当前状态：**component-partial / 先由 v1.2.2 接续，随后由 v1.2.3 完成修复**。
+当前稳定版为 [v1.3.2](/releases/v1-3-2)；v1.2.3 仅保留为上一稳定回滚基线。
 
 实际结果：Framework 与 V6 前端已从
 `80d2d20f1b44105e18706cfa0deb7f8512966f92` 发布；根标签和 runtime image 已创建，
 但根工作流仍上传原始 V6 `dist`，再次因含 `:` 的路径失败，最终平台 ZIP 和根 GitHub
-Release 未发布。所有 v1.2.1 公开引用保持不可变；活动修复见
+Release 未发布。所有 v1.2.1 公开引用保持不可变；当时的完整前向修复见
 [v1.2.3 发布合同](/releases/v1-2-3)。
 
 v1.2.1 是 v1.2.0 不完整同步列车的前向修复版本。根仓库、可复用 Framework 和唯一的

--- a/docs/docs/releases/v1-2-2.md
+++ b/docs/docs/releases/v1-2-2.md
@@ -10,12 +10,13 @@ keywords: [v1.2.2 release portable artifact windows archive antd-v6 rollback]
 
 # v1.2.2 发布合同
 
-当前状态：**component-partial / 已由 v1.2.3 接续**。
+当前状态：**component-partial / 已由 v1.2.3 完成修复**。
+当前稳定版为 [v1.3.2](/releases/v1-3-2)；v1.2.3 仅保留为上一稳定回滚基线。
 
 Framework 与唯一 V6 前端已从精确提交
 `29a99f2bdb9a2c516459529918795404c153df2e` 公开，根候选资格和根标签也已完成；根
 多架构镜像随后因 arm64 在 QEMU 中编译 2320 秒、到 40 分钟上限时仍在导出和推送而失败，
-因此根镜像和根 GitHub Release 未完成。所有 v1.2.2 公开引用保持不可变；活动修复见
+因此根镜像和根 GitHub Release 未完成。所有 v1.2.2 公开引用保持不可变；当时的完整前向修复见
 [v1.2.3 发布合同](/releases/v1-2-3)。
 
 v1.2.2 是 v1.2.1 根发行不完整后的同步前向修复。根仓库、可复用 Framework 和唯一的

--- a/docs/docs/releases/v1-2-3.md
+++ b/docs/docs/releases/v1-2-3.md
@@ -10,7 +10,8 @@ keywords: [v1.2.3 release docs multi-architecture container cross-compile arm64 
 
 # v1.2.3 发布合同
 
-当前状态：**v1.2.3 已发布；各组件保留独立、不可变的版本标识**。
+当前状态：**v1.2.3 已发布并保留为上一稳定回滚基线；当前稳定版为
+[v1.3.2](/releases/v1-3-2)**。各组件继续保留独立、不可变的版本标识。
 
 v1.2.3 最初是 v1.2.2 根镜像发布不完整后的同步前向修复。根仓库、可复用 Framework 和唯一的
 Ant Design V6 前端保持同提交运行时合同；Docs 使用独立组件版本线，可以从另一个已合并到

--- a/docs/docs/releases/v1-3-0.md
+++ b/docs/docs/releases/v1-3-0.md
@@ -16,7 +16,8 @@ keywords: [v1.3.0 component partial immutable release history]
 Framework <code>mss-boot/v1.3.0</code> 已公开；Admin 发布在独立 Module 元数据门禁失败，
 Root、Admin Web、Docs 和 npmjs stable 制品均未完成。已有标签、Release 和失败记录永久
 保持不变。下文仅保留当时的计划合同作为审计证据，不得据此继续发布、安装或升级。
-当前活动目标是 [v1.3.2](/releases/v1-3-2)，已对账稳定版仍是 <code>v1.2.3</code>。
+后续完整列车 [v1.3.2](/releases/v1-3-2) 已发布并完成对账，是当前稳定版；
+<code>v1.2.3</code> 仅保留为上一稳定回滚基线。
 :::
 
 ## 1. 原计划发行范围

--- a/docs/docs/releases/v1-3-1.md
+++ b/docs/docs/releases/v1-3-1.md
@@ -12,7 +12,8 @@ keywords: [v1.3.1 partial release checksum admin framework]
 
 :::warning
 `v1.3.1` 是不可变的 component-partial 历史，不是一组可部署的 Complete Admin
-Distribution。当前活动目标是 [v1.3.2](/releases/v1-3-2)，当前已对账稳定版仍是 `v1.2.3`。
+Distribution。后续完整列车 [v1.3.2](/releases/v1-3-2) 已发布并完成对账，是当前稳定版；
+`v1.2.3` 仅保留为上一稳定回滚基线。
 :::
 
 ## 不可变结果
@@ -42,5 +43,6 @@ Framework README 与 CHANGELOG，公共模块的规范 Sum 发生变化；`GOWOR
 
 ## 恢复与回滚
 
-在 v1.3.2 完成全部公开发布与对账前，生产回滚基线仍是 v1.2.3。不要把
-`mss-boot/v1.3.1` 与任何 v1.2.3 Admin、前端或 Thin Host 混合为受支持发行包。
+该失败发生时，生产回滚基线仍是 v1.2.3；现在 v1.3.2 已完成全部公开发布与对账，
+是当前稳定版，v1.2.3 是上一稳定回滚基线。不要把 `mss-boot/v1.3.1` 与任何
+v1.2.3 Admin、前端或 Thin Host 混合为受支持发行包。

--- a/docs/docs/releases/v1-3-2.md
+++ b/docs/docs/releases/v1-3-2.md
@@ -99,6 +99,15 @@ go run ./cmd/mss --root ../orders-admin upgrade admin v1.3.2 \
 浏览器证据统一记录在
 [发布证据 issue #519](https://github.com/mss-boot-io/mss-boot-admin/issues/519)。
 
+## 发布后 npm 安全状态
+
+- npmjs 的 `latest` dist-tag 已指向 `@mss-boot-io/admin-web@1.3.2`；
+- Trusted Publisher 使用 GitHub Actions，限定为 `mss-boot-io/mss-boot-admin`、
+  `npm-release.yml`、`release-v6`，且只允许 `npm publish`；
+- 一次性 npm bootstrap Token 已撤销，npm Token 列表为空；
+- GitHub `release-v6` 环境中的 `NPM_TOKEN` Secret 已删除并验证不存在；
+- 后续发布没有 Token 回退，OIDC 身份不匹配时失败关闭。
+
 ## 回滚
 
 v1.2.3 是 v1.3.2 的上一稳定版与协调回滚基线。回滚必须同时恢复已验证的

--- a/tools/compatibility/test-thin-host-external-consumer.sh
+++ b/tools/compatibility/test-thin-host-external-consumer.sh
@@ -64,6 +64,17 @@ foundation_root="$(realpath -- "${foundation_root}")"
   exit 1
 }
 
+expected_pnpm_version='10.34.5'
+command -v pnpm >/dev/null 2>&1 || {
+  echo "pnpm ${expected_pnpm_version} must be installed before Thin Host qualification" >&2
+  exit 1
+}
+actual_pnpm_version="$(pnpm --version)"
+[[ "${actual_pnpm_version}" = "${expected_pnpm_version}" ]] || {
+  echo "Thin Host qualification requires pnpm ${expected_pnpm_version}; found ${actual_pnpm_version}" >&2
+  exit 1
+}
+
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/mss-thin-host-consumer.XXXXXX")"
 backend_pid=""
 web_pid=""
@@ -380,7 +391,7 @@ if [[ -z "${tarball}" ]]; then
   (
     cd "${package_source}"
     npm pkg set "gitHead=${foundation_commit}" >/dev/null
-    corepack pnpm@10.34.5 pack --pack-destination "${pack_dir}" >/dev/null
+    pnpm pack --pack-destination "${pack_dir}" >/dev/null
   )
   mapfile -t packed_tarballs < <(find "${pack_dir}" -maxdepth 1 -type f -name '*.tgz' -print)
   [[ ${#packed_tarballs[@]} -eq 1 ]] || {
@@ -414,7 +425,7 @@ web_root="${host_root}/web"
 (
   cd "${web_root}"
   # This local tarball qualification never contacts either public registry.
-  corepack pnpm@10.34.5 add \
+  pnpm add \
     --save-exact \
     --lockfile-only \
     --ignore-scripts \
@@ -442,12 +453,12 @@ if entry.get('specifier') != expected or not (
 ):
     raise SystemExit(f'external host lock importer does not bind the qualified tarball: {entry!r}')
 PY
-  corepack pnpm@10.34.5 fetch --frozen-lockfile
-  corepack pnpm@10.34.5 install --offline --frozen-lockfile --ignore-scripts
-  corepack pnpm@10.34.5 run lint
-  corepack pnpm@10.34.5 run test
-  corepack pnpm@10.34.5 run build
-  corepack pnpm@10.34.5 list --json --depth Infinity \
+  pnpm fetch --frozen-lockfile
+  pnpm install --offline --frozen-lockfile --ignore-scripts
+  pnpm run lint
+  pnpm run test
+  pnpm run build
+  pnpm list --json --depth Infinity \
     > "${artifact_dir}/pnpm-tree.raw.json"
 )
 
@@ -585,7 +596,7 @@ mss_start_process_group \
   REACT_APP_ENV=dev \
   UMI_ENV=dev \
   MOCK=none \
-  corepack pnpm@10.34.5 run dev
+  pnpm run dev
 wait_for_http \
   "external Thin Host frontend" \
   "http://127.0.0.1:18001/admin/api/languages/public" \
@@ -611,7 +622,7 @@ set +e
   MSS_E2E_BACKEND_API_URL=http://127.0.0.1:18080/admin/api \
   MSS_E2E_USERNAME="${MSS_E2E_USERNAME:-admin}" \
   MSS_E2E_PASSWORD="${MSS_E2E_PASSWORD:-123456}" \
-    corepack pnpm@10.34.5 exec playwright test \
+    pnpm exec playwright test \
       e2e/generated/supplier.spec.ts \
       e2e/permission.spec.ts \
       e2e/parity.spec.ts \

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -83,20 +83,20 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
         frontend_install = self.step("Install frontend dependencies")["run"]
         self.assertEqual(
             frontend_install,
-            "corepack pnpm@10.34.5 --dir web/antd-v6 install --frozen-lockfile --ignore-scripts",
+            "pnpm --dir web/antd-v6 install --frozen-lockfile --ignore-scripts",
         )
         playwright_install = self.step("Install Playwright Chromium")
         self.assertEqual(playwright_install["if"], RUNTIME_PHASE_CONDITION)
         self.assertEqual(playwright_install["working-directory"], "web/antd-v6")
         self.assertEqual(
             playwright_install["run"],
-            "corepack pnpm@10.34.5 exec playwright install --with-deps chromium",
+            "pnpm exec playwright install --with-deps chromium",
         )
         self.assertLess(
             self.steps.index(playwright_install),
             self.steps.index(phase),
         )
-        self.assertEqual(self.step("Setup pnpm")["with"]["version"], "9.15.9")
+        self.assertEqual(self.step("Setup pnpm")["with"]["version"], "10.34.5")
 
     def test_publication_authority_phases_execute_and_only_checkpoint_plans(self):
         for step_name in (

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -396,6 +396,12 @@ class WorkflowGovernanceTest(unittest.TestCase):
         self.assertIn(
             "playwright install --with-deps chromium", browser_install["run"]
         )
+        setup_pnpm = next(
+            step
+            for step in jobs["external-consumer"]["steps"]
+            if step.get("name") == "Setup pnpm"
+        )
+        self.assertEqual(setup_pnpm["with"]["version"], "10.34.5")
 
         thin_host_script = (
             REPOSITORY_ROOT
@@ -421,6 +427,9 @@ class WorkflowGovernanceTest(unittest.TestCase):
             "resolved.startswith(expected + '(')",
             "fetch --frozen-lockfile",
             "install --offline --frozen-lockfile",
+            "expected_pnpm_version='10.34.5'",
+            'actual_pnpm_version="$(pnpm --version)"',
+            "pnpm pack --pack-destination",
             'mss_start_process_group \\\n  backend_pid',
             'mss_start_process_group \\\n  web_pid',
             'mss_stop_process_group "${web_pid}"',
@@ -428,6 +437,7 @@ class WorkflowGovernanceTest(unittest.TestCase):
         ):
             with self.subTest(required=required):
                 self.assertIn(required, thin_host_script)
+        self.assertNotIn("corepack pnpm@10.34.5", thin_host_script)
         process_group_helper = (
             REPOSITORY_ROOT
             / "tools"

--- a/web/antd-v6/CHANGELOG.md
+++ b/web/antd-v6/CHANGELOG.md
@@ -19,6 +19,10 @@ integrity is
 `sha512-24K4Js0wk5J44AK8/3EyRksfn1pR7NViv0zG17myMwzKFmXNTOv9BOZJdk4SpWVLUop3DJKkBXYwsEFixZ+6lA==`,
 and the frontend image digest is
 `sha256:f52ef4664cfd419356805c74567f7317b4a2086467d729366ee2097efbf9ac1e`.
+The public npm `latest` tag resolves to `1.3.2`. Future publication uses npm
+Trusted Publishing bound to repository `mss-boot-io/mss-boot-admin`, workflow
+`npm-release.yml`, and environment `release-v6`; the one-time bootstrap token
+and GitHub secret are absent.
 
 The v1.3.1 Admin Web tag, package, image, and Release were never published after
 the coordinated train stopped at the Admin checksum gate, so v1.3.2 used the next


### PR DESCRIPTION
## Summary

- make `v1.3.2` at `635fbb03a82976941e527d8ac1000fec0624abac` the canonical current stable baseline across the root README, security policy, changelogs, Docs site, release history, and architecture decisions
- preserve `v1.2.3` as the previous-stable coordinated rollback baseline and mark v1.3.0/v1.3.1 plus RC trains as immutable historical evidence
- record the completed npm state: `latest=1.3.2`, exact Trusted Publisher binding to `mss-boot-io/mss-boot-admin` / `npm-release.yml` / `release-v6`, and removal of bootstrap token fallback
- reconcile machine-readable capability, command, and v1.3.2 release contracts without promoting still-Beta extension capabilities
- keep the published `mss-boot` module tree unchanged so its public v1.3.2 Module Sum remains valid

## Validation

- all Feature and AdminModule specifications validated
- `python3 -m unittest discover -s tools/release -p 'test_*.py'`: 132 passed
- v1.3.2 release-policy qualification accepted for root, Framework, Admin, frontend, and Docs
- `corepack pnpm@9.15.9 --dir docs build`: passed, including portable static-path validation
- `go run ./cmd/mss verify --changed`: passed
  - contract validation
  - Agent tooling tests
  - Docs build
  - frontend lint / TypeScript
  - frontend tests
  - Git diff check
- Framework/Admin checksum parity remains exact:
  - Module Sum `h1:6lncRvnlRbA8GMF9cnOnpwctv+1A1afrmP6c2ZJ4CxQ=`
  - GoMod Sum `h1:ORk2A6CLcwJkfnnHq7IXZQD22H47TUHJ1yau9K3StvA=`
- read-only public checks reconfirmed npm `latest=1.3.2`, npm `gitHead=635fbb03a82976941e527d8ac1000fec0624abac`, and zero `release-v6` GitHub environment secrets

## Impact

- no runtime code, migration, dependency, module metadata, lockfile, tag, Release, image, or package change
- no credential material added; bootstrap credentials remain revoked and absent
- historical release identities remain immutable

Evidence index: #519
