### PR TITLE
fix(docs): deploy v1.3.2 site revision

### DIFF
--- a/.agents/skills/mss-release/SKILL.md
+++ b/.agents/skills/mss-release/SKILL.md
@@ -50,6 +50,8 @@ For a component-only or downstream release, retain the same source, evidence, im
 
 The foundation components are independently releasable. A Docs-only release uses `docs/{version}` and does not recreate root, Framework, or frontend refs. Qualify the documentation build and browser evidence on the Docs candidate, merge through PR, freeze the resulting exact `origin/main` commit, create only the Docs tag, wait for the tag-triggered Docs workflow and protected `prod` deployment, then reconcile the Docs Release assets, checksums, public `release.json`, and visible site against that commit.
 
+When the coordinated Docs tag for the current stable version already exists but later merged documentation must replace stale public content, preserve that tag and use the lowest unused positive Docs revision allowed by policy, such as `docs/v1.3.2+docs.1`. A `+docs.N` tag updates only the Docs component, does not consume the next product patch version, and must still pass the exact merged-main source guard, protected deployment, Release, `/release.json`, and browser reconciliation.
+
 ## Procedure
 
 ### 1. Establish source and policy

--- a/.agents/skills/mss-update-release-docs/SKILL.md
+++ b/.agents/skills/mss-update-release-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mss-update-release-docs
-description: Reconcile MSS release documentation and machine-readable guidance to one exact stable, current, candidate, or historical release baseline. Trigger for post-release documentation, stable-version changes, README and changelog version sweeps, release-note reconciliation, install or image example updates, and correcting stale “latest” claims after publication. Do not use this skill to create or move tags, publish artifacts, or rewrite immutable release history.
+description: Reconcile MSS source documentation, machine-readable guidance, and public Docs-site state to one exact stable, current, candidate, or historical release baseline. Trigger for post-release documentation, stable-version changes, README and changelog version sweeps, release-note reconciliation, install or image example updates, stale “latest” claims, and a deployed Docs site that still shows old release facts. Do not use this skill by itself to create or move tags or publish artifacts; route authorized publication through the MSS release workflow.
 ---
 
 # Update MSS release documentation
@@ -18,6 +18,7 @@ Record a compact ledger:
 - exact merged-main commit;
 - root, Framework, Admin, frontend, Docs, image, and package tag names as applicable;
 - public Release, registry, image digest, and evidence references;
+- public Docs URL plus its `/release.json` version and full commit;
 - previous stable and rollback baseline;
 - capability maturity that has independent evidence.
 
@@ -62,6 +63,19 @@ A tagged Go module checksum covers every file in that module tree, including doc
 
 Do not change `go.mod`, `go.sum`, `go.work`, `go.work.sum`, pnpm lockfiles, or package metadata merely to make documentation validation pass. Do not move or recreate an existing release tag to pick up documentation changes. A source-documentation PR merged into `main` does not silently update an immutable Docs deployment; that requires the repository's explicit Docs release path.
 
+## Close the source-to-site gap
+
+When the repository has a public Docs domain, source reconciliation is not the same as publication:
+
+1. Before editing, record the visible home page and a nested release route in the available browser, and read the public `/release.json` version and full commit.
+2. After the source PR merges, compare that identity with the exact merged `main` commit. If the site still exposes an older commit or stale visible claims, report the state as `source-updated / deployment-pending`, never complete.
+3. If the user authorized a public-site update, use `mss-release` for the mutation. Publish only from the exact merged-main commit after its Docs build and browser evidence pass.
+4. Preserve an existing coordinated Docs tag. For a correction to the current stable documentation, select the lowest unused positive revision accepted by policy, such as `docs/v1.3.2+docs.1`; this is a Docs component revision, not a new product version.
+5. Wait for the tag-triggered workflow, protected production environment, portable archive checksums, public `/release.json`, and immutable GitHub Release. A successful main-branch Docs build without the tag deployment is preliminary evidence only.
+6. Reopen the production home page and a nested release route, refresh both, verify visible stable-version language, inspect console errors and failed network requests, and save final screenshots.
+
+If publication was not authorized or the environment cannot be approved, stop before creating a tag and provide the exact proposed Docs revision, merged commit, workflow, and remaining approval step.
+
 ## Validate proportionally
 
 Start with the cheapest relevant checks and use commands declared by `.mss/commands.yaml`:
@@ -98,3 +112,4 @@ Report:
 - commands actually run and their results;
 - skipped checks with concrete reasons;
 - merged commit and any separate Docs release still required.
+- source state and public-site state separately, including the deployed Docs tag, `/release.json`, workflow run, Release, browser routes, and screenshot paths.

--- a/.agents/skills/mss-update-release-docs/agents/openai.yaml
+++ b/.agents/skills/mss-update-release-docs/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MSS Release Docs"
-  short_description: "Reconcile MSS documentation around an exact release baseline"
-  default_prompt: "Reconcile release documentation against exact repository and public artifact evidence, preserve immutable history, validate the docs and contracts, and report remaining risks."
+  short_description: "Reconcile MSS source and deployed release documentation"
+  default_prompt: "Reconcile release documentation against exact repository, public artifact, and Docs-site evidence; preserve immutable history, validate source and browser-facing contracts, and distinguish merged source from deployed public state."

--- a/.mss/features/foundation-v1-3-2-release.yaml
+++ b/.mss/features/foundation-v1-3-2-release.yaml
@@ -28,6 +28,7 @@ spec:
     - Calculate the v1.3.2 Framework Module and go.mod sums from the final tracked tree and compare them with Admin metadata before tagging.
     - Publish Framework, Admin, Admin Web, root, and Docs from one exact clean commit already merged into main.
     - Publish the qualified Admin Web tarball to npmjs only after every coordinated GitHub artifact is public and reconciled.
+    - Keep the public Docs site aligned with later merged documentation by using immutable Docs-only revision tags instead of moving docs/v1.3.2.
   nonGoals:
     - Move, delete, overwrite, or reuse any v1.3.1 or release-candidate ref.
     - Publish any component from this pull-request branch or from a commit absent from current origin/main.
@@ -66,6 +67,7 @@ spec:
       rules:
         - Root uses v1.3.2, Framework uses mss-boot/v1.3.2, Admin uses admin/v1.3.2, and Admin Web uses web/antd-v6/v1.3.2.
         - The frontend package uses 1.3.2 and Docs uses the independent docs/v1.3.2 namespace.
+        - The initial Docs release remains at docs/v1.3.2; later current-stable site corrections use unused docs/v1.3.2+docs.N revisions without changing the product version.
         - The release policy rejects v1.3.1, prereleases, and every unreviewed later version.
         - Current stable is v1.3.2 at exact commit 635fbb03a82976941e527d8ac1000fec0624abac after publication and public reconciliation.
     - id: preserve-v131-history
@@ -262,6 +264,17 @@ spec:
       evidence:
         - type: report
           value: GitHub issue #519 records exact tags, Releases, Go sums, npm provenance and byte parity, image digests, Docs identity, checksums, and current-stable reconciliation.
+    - id: post-publication-docs-site-revision
+      requirement: document-patch-release
+      statement: A later merged documentation correction can update the public site without moving the coordinated docs/v1.3.2 tag or consuming a future product patch version.
+      level: e2e
+      phase: post-publication
+      required: true
+      evidence:
+        - type: command
+          value: python3 tools/release/check_release_policy.py --component docs --version v1.3.2+docs.1 --tag docs/v1.3.2+docs.1 --intent qualify
+        - type: report
+          value: The tag-triggered Docs workflow, protected prod deployment, GitHub Release, portable checksums, public release.json, refreshed nested route, console, failed-network, and screenshot evidence all resolve to the exact revision commit.
   risks:
     - id: public-dependency-order
       description: Admin cannot run independently until the exact v1.3.2 Framework module is public.
@@ -279,6 +292,10 @@ spec:
       description: A binary rollback without its matching data backup can leave an incompatible authorization or schema projection.
       severity: critical
       mitigation: Require a verified backup and matched artifact inventory before migration and restore both data and coordinated v1.2.3 artifacts on rollback.
+    - id: stale-public-docs
+      description: A successful main-branch Docs build can leave the public site on an older immutable Docs tag and continue presenting obsolete stable-version claims.
+      severity: high
+      mitigation: Track source and deployed identities separately, publish an unused docs/v1.3.2+docs.N revision from merged main, and verify release.json plus visible routes in the browser.
   validation:
     changed: go run ./cmd/mss verify --changed
     all: go run ./cmd/mss verify --all

--- a/docs/docs/releases/index.md
+++ b/docs/docs/releases/index.md
@@ -36,10 +36,19 @@ keywords: [release upgrade rollback compatibility mss-boot-admin thin host]
 | Framework | <code>mss-boot/v1.3.2</code> |
 | Admin Go Module | <code>admin/v1.3.2</code> |
 | Admin Web | <code>web/antd-v6/v1.3.2</code> 与 <code>@mss-boot-io/admin-web@1.3.2</code> |
-| Docs | 独立的 <code>docs/v1.3.2</code> |
+| Docs | 初始协调标签 <code>docs/v1.3.2</code>；站点内容修订 <code>docs/v1.3.2+docs.1</code> |
 
 Root、Framework、Admin、Admin Web 和 Docs 均发布自同一个已合并 <code>main</code> 的精确提交
 <code>635fbb03a82976941e527d8ac1000fec0624abac</code>。Docs 仍保留独立标签和发布工作流。
+
+### Docs 站点修订
+
+<code>docs/v1.3.2</code> 保持为协调发布时的不可变 Docs 标签。协调发布之后合并的稳定版文档
+不会通过 <code>main</code> 构建自动替换公开站点；本次站点对账使用
+<code>docs/v1.3.2+docs.1</code> 从新的精确 merged-main 提交触发独立 Docs 部署。
+<code>+docs.1</code> 只表示文档组件修订，不发布 v1.3.3 产品、不改变任何 v1.3.2 Go Module、
+npm 包、镜像或 Root 制品。公开 <code>/release.json</code>、Docs Release、校验和与浏览器可见
+内容全部收敛后，站点更新才算完成。
 
 ## v1.3.2 当前稳定版
 

--- a/docs/docs/releases/v1-3-2.md
+++ b/docs/docs/releases/v1-3-2.md
@@ -30,10 +30,16 @@ Framework Sum 与最终公开树不一致；Admin Release 与后续组件均未�
 | Framework | `mss-boot/v1.3.2` |
 | Admin Go Module | `admin/v1.3.2` |
 | Admin Web | `web/antd-v6/v1.3.2`、`@mss-boot-io/admin-web@1.3.2` |
-| Docs | `docs/v1.3.2` |
+| Docs | 初始协调标签 `docs/v1.3.2`；站点内容修订 `docs/v1.3.2+docs.1` |
 
 所有身份均解析到同一个已合并 `main` 的完整 SHA。实际发布顺序为：feature-freeze、
 pre-framework、Framework、Admin、Admin Web、pre-root、Root、Docs、官方 npm、只读对账。
+
+`docs/v1.3.2` 保持不可变并继续证明最初协调发布。稳定版文档在该标签之后合入 `main` 时，
+公开站点通过 `docs/v1.3.2+docs.N` 修订前向更新；修订号选择尚未使用的最小正整数。
+Docs 修订不改变产品稳定版本，也不重新发布 Framework、Admin、Admin Web、Root、npm 或镜像。
+本次站点对账使用 `docs/v1.3.2+docs.1`，并以公开 `/release.json`、GitHub Release、部署
+校验和和浏览器可见内容作为完成证据。
 
 ## 校验和修复
 

--- a/tools/release/check_release_policy.py
+++ b/tools/release/check_release_policy.py
@@ -14,6 +14,10 @@ VERSION_RE = re.compile(
     r"(?:-(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
     r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$"
 )
+DOCS_REVISION_RE = re.compile(
+    r"^(?P<base>v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*))\+docs\.(?P<revision>[1-9][0-9]*)$"
+)
 REQUIRED_KEYS = {
     "mode",
     "releaseBranch",
@@ -156,10 +160,20 @@ def check_public_ref(
     tag: str,
     intent: str = "publish",
 ) -> None:
-    if not VERSION_RE.fullmatch(version):
+    docs_revision = (
+        DOCS_REVISION_RE.fullmatch(version) if component == "docs" else None
+    )
+    if not VERSION_RE.fullmatch(version) and docs_revision is None:
         raise PolicyError(f"invalid release version: {version}")
     target = policy["nextPublicVersion"]
-    if version != target:
+    if docs_revision is not None:
+        stable = policy["currentStableVersion"]
+        if docs_revision.group("base") != stable:
+            raise PolicyError(
+                f"docs revision base {docs_revision.group('base')} is forbidden "
+                f"while current stable is {stable}"
+            )
+    elif version != target:
         raise PolicyError(
             f"public version {version} is forbidden while the reviewed target is {target}"
         )

--- a/tools/release/test_check_release_policy.py
+++ b/tools/release/test_check_release_policy.py
@@ -48,6 +48,33 @@ class ReleasePolicyTest(unittest.TestCase):
         self.assertIs(self.policy["publicPrereleases"], False)
         POLICY.check_public_ref(self.policy, "root", "v1.3.2", "v1.3.2")
 
+    def test_docs_revision_can_publish_current_stable_without_reusing_its_tag(self):
+        for intent in ("qualify", "publish"):
+            with self.subTest(intent=intent):
+                POLICY.check_public_ref(
+                    self.policy,
+                    "docs",
+                    "v1.3.2+docs.1",
+                    "docs/v1.3.2+docs.1",
+                    intent=intent,
+                )
+
+    def test_docs_revision_is_confined_to_current_stable_and_docs_namespace(self):
+        cases = (
+            ("docs", "v1.2.3+docs.1", "docs/v1.2.3+docs.1", "current stable"),
+            ("docs", "v1.3.2+docs.0", "docs/v1.3.2+docs.0", "invalid"),
+            ("docs", "v1.3.2+docs.01", "docs/v1.3.2+docs.01", "invalid"),
+            ("docs", "v1.3.2+other.1", "docs/v1.3.2+other.1", "invalid"),
+            ("root", "v1.3.2+docs.1", "v1.3.2+docs.1", "invalid"),
+            ("docs", "v1.3.2+docs.1", "docs/v1.3.2", "does not match"),
+        )
+        for component, version, tag, message in cases:
+            with self.subTest(component=component, version=version, tag=tag):
+                with self.assertRaisesRegex(POLICY.PolicyError, message):
+                    POLICY.check_public_ref(
+                        self.policy, component, version, tag, intent="qualify"
+                    )
+
     def test_policy_requires_pr_merged_main_release_source(self):
         self.assertEqual(self.policy["releaseBranch"], "main")
         self.assertIs(self.policy["requireMergedPullRequestSource"], True)


### PR DESCRIPTION
## Summary

- close the gap between merged release documentation and the deployed Docs site
- allow immutable Docs-only revisions such as `docs/v1.3.2+docs.1` for the current stable product version
- teach the release-documentation Skill to track source and public-site state separately and require browser reconciliation
- document the v1.3.2 Docs revision without changing the product version or republishing other components

## Validation

- `python3 -m unittest discover -s tools/release -p 'test_*.py'` — 134 passed
- `go run ./cmd/mss verify --changed` — passed with Go 1.26.6 and Node 22.22.0
- `corepack pnpm@9.15.9 --dir docs audit:release` — passed; 0 production blockers
- Docs production build and portable static-distribution check — passed
- `git diff --check` — passed
- in-app browser: local production build home and `/releases/v1-3-2` opened and refreshed; expected stable/revision text visible; no site-origin console errors or failed asset requests

## Release impact

- preserves the existing immutable `docs/v1.3.2` tag
- enables only a Docs component revision from an exact commit already merged into `main`
- does not alter Go modules, npm packages, images, Root artifacts, module metadata, or lockfiles

## Security and compatibility

- no credentials or runtime behavior changed
- no database migration
- release policy rejects revisions for non-Docs components, wrong stable bases, zero/leading-zero revisions, unrelated metadata, and mismatched tags
