### PR TITLE
feat(admin): establish governed presentation configuration P0

### DIFF
--- a/.mss/capabilities.yaml
+++ b/.mss/capabilities.yaml
@@ -158,6 +158,28 @@ spec:
         capability in beta while the pinned ProComponents v3 dependency remains a prerelease, and require one
         Codex in-app Browser acceptance record for each release candidate instead of expanding a cross-browser matrix.
 
+    - id: platform.presentation-configuration
+      displayName: Governed Admin Page Presentation Configuration
+      status: planned
+      owners: [frontend, backend, security, agent-infrastructure]
+      paths:
+        - .mss/features/admin-presentation-configuration.yaml
+        - .mss/schemas/admin-page-presentation.schema.json
+        - docs/adr/2026-08-24-governed-admin-presentation-configuration.md
+      frontendPaths:
+        - web/antd-v6/src/shared/presentation
+      guidance: >-
+        P0 defines a strict data-only sparse profile over compiled page, field, data-source,
+        component, action, and permission capabilities and proves it with a non-production Supplier
+        prototype. Code defaults resolve beneath application, role, and user layers; exact definition
+        hash validation rejects stale profiles, and trusted permissions are intersected last. The
+        prototype has no production route, persistence, API, menu, migration, browser storage, or
+        generated-file replacement. Keep this capability Planned until a separately reviewed P1 adds
+        authoritative draft, ETag publish, immutable history, rollback, audit, drift diagnostics,
+        recovery mode, and browser evidence. Never add scripts, HTML, SQL, transport definitions,
+        component imports, permissions, runtime models, virtual CRUD, or browser code generation to a
+        presentation profile.
+
     - id: platform.cache-lock-queue
       displayName: Legacy Cache, Distributed Lock, and Queue Adapters
       status: legacy

--- a/.mss/features/admin-presentation-configuration.yaml
+++ b/.mss/features/admin-presentation-configuration.yaml
@@ -1,0 +1,272 @@
+apiVersion: mss.io/v1alpha1
+kind: Feature
+metadata:
+  name: admin-presentation-configuration
+  displayName: Governed Admin page presentation configuration
+  description: >-
+    Defines the trusted capability registry, sparse page-presentation overlays, deterministic
+    precedence, fail-closed drift handling, and a non-production Supplier prototype for making
+    approved Admin display choices configurable without runtime code generation.
+  owner: admin-platform
+  labels:
+    domain: configuration
+    scope: presentation
+    phase: p0-contract-prototype
+spec:
+  problem: >-
+    Admin pages are compiled safely but many display decisions remain embedded in React source.
+    Operators therefore need code changes for routine column, search, form, detail, label, order,
+    density, and action-placement changes. The repository also permanently removed runtime dynamic
+    models and browser code generation, so stronger configuration must remain inside compiled data,
+    component, action, route, and permission boundaries instead of recreating a low-code runtime.
+  goals:
+    - Define one strict versioned document for sparse Admin page-presentation overlays.
+    - Keep fields, data sources, components, actions, routes, and permissions in a trusted compile-time capability registry.
+    - Resolve code defaults, application, role, and user presentation layers deterministically while applying authorization last.
+    - Reject definition drift and unknown capability references as a whole profile with a safe fallback.
+    - Prove the contract with a non-persistent Supplier list-page prototype without changing production routing.
+    - Record a phased path from the P0 prototype to governed draft, publish, history, rollback, and visual editing.
+  nonGoals:
+    - Add database tables, migrations, HTTP APIs, caching, drafts, publishing, history, rollback, or an editor in P0.
+    - Replace the current Supplier production route or hand-edit any generated Supplier file.
+    - Create fields, database columns, models, APIs, data-source URLs, HTTP methods, headers, workflows, permissions, or routes at runtime.
+    - Execute JavaScript, expressions, SQL, HTML, imports, templates, plugins, or downloaded code from presentation configuration.
+    - Reintroduce dynamic models, virtual CRUD, runtime developer tools, browser code generation, micro-frontends, or remote modules.
+    - Make authentication, authorization, application configuration, or recovery pages configurable before later security qualification.
+  actors:
+    - id: page-operator
+      displayName: Page configuration operator
+      description: Selects allowed presentation options without gaining data or action permissions.
+    - id: platform-maintainer
+      displayName: Admin platform maintainer
+      description: Registers trusted capabilities and evolves schemas, generators, and renderers.
+    - id: security-reviewer
+      displayName: Security reviewer
+      description: Verifies that untrusted overlays cannot expand backend authority or load code.
+  modules:
+    - name: presentation-contract
+      kind: infrastructure
+      operation: create
+      description: Versioned JSON Schema, TypeScript types, identifiers, scope, and sparse overlay semantics.
+    - name: presentation-resolver
+      kind: infrastructure
+      operation: create
+      description: Registry validation, layer precedence, drift rejection, permission intersection, and render-model projection.
+    - name: supplier-presentation-prototype
+      kind: infrastructure
+      operation: create
+      description: Non-production capability manifest and compact Supplier overlay used only by contract tests.
+  requirements:
+    - id: define-trusted-capabilities
+      title: Define the trusted capability side of the boundary
+      description: Maintained or generated code declares everything a presentation profile is allowed to reference.
+      priority: must
+      actor: platform-maintainer
+      module: presentation-contract
+      rules:
+        - Every page capability has a stable page key, semantic definition version, and sha256 definition hash.
+        - Fields declare supported surfaces, value type, required state, sort and filter support, and allowed registered components.
+        - Data sources and actions carry opaque backend permission identifiers in trusted code rather than in editable profiles.
+        - Components, data sources, actions, and fields use stable identifiers and reject duplicates.
+        - Default presentation is complete, immutable input to resolution, and is not modified by an overlay.
+    - id: constrain-presentation-documents
+      title: Keep presentation documents sparse and data-only
+      description: The public profile schema exposes routine presentation choices without an executable or transport surface.
+      priority: must
+      actor: page-operator
+      module: presentation-contract
+      rules:
+        - The document uses apiVersion mss.io/v1alpha1 and kind AdminPagePresentation with strict additionalProperties false objects.
+        - Metadata binds a profile to one page key, one exact definition hash, and application, role, or user scope.
+        - Profiles may adjust localized text, field visibility, component choice, order, width, span, density, page size, sort, layout, action placement, and bounded declarative visibility conditions.
+        - Profiles contain only identifiers and scalar data and cannot carry permissions, routes, URLs, methods, headers, HTML, scripts, imports, SQL, or arbitrary expressions.
+        - Shape validation is followed by capability-aware semantic validation; JSON Schema alone never authorizes a reference.
+    - id: resolve-layered-presentation
+      title: Resolve deterministic sparse presentation layers
+      description: One pure resolver produces a renderer-ready model from trusted defaults and at most one profile per supported layer.
+      priority: must
+      actor: page-operator
+      module: presentation-resolver
+      rules:
+        - Precedence is code defaults, application profile, role profile, then current-user profile.
+        - Missing values inherit and explicit false values remain explicit rather than being treated as absent.
+        - A page-key mismatch, definition-hash mismatch, unknown reference, duplicate reference, unsupported surface, invalid component, or unsafe required-field hide rejects the complete offending layer.
+        - Rejected layers leave lower valid layers intact and return structured diagnostics for later audit and editor feedback.
+        - A trusted invalid capability definition fails closed during development instead of silently producing a partial page.
+    - id: preserve-authorization-boundary
+      title: Apply authorization after presentation resolution
+      description: Editable display choices never create authority or reveal a protected data source.
+      priority: must
+      actor: security-reviewer
+      module: presentation-resolver
+      rules:
+        - The selected data source is usable only when the current verified permission set contains its trusted required permission.
+        - Every resolved action is intersected with the trusted action permission after all profile layers are applied.
+        - A profile can hide or reorder a registered action but cannot supply, replace, or remove its permission requirement.
+        - A missing data-source permission yields a permission-denied render model and no visible actions.
+        - Frontend intersection remains a user-experience guard and does not replace backend authorization tests or enforcement.
+    - id: prove-supplier-reference
+      title: Prove one representative generated-domain reference
+      description: Supplier demonstrates the contract against an existing generated business capability without modifying generated output.
+      priority: must
+      actor: platform-maintainer
+      module: supplier-presentation-prototype
+      rules:
+        - The prototype capability derives its field, component, action, and permission choices from the existing Supplier AdminModule contract.
+        - A compact application profile changes title, visible list columns, ordering, density, page size, and action visibility using only profile data.
+        - Contract tests prove application, role, and user precedence, drift fallback, unknown-reference rejection, required-field safety, immutability, and authorization-last behavior.
+        - The prototype is not imported by production routes and creates no API request, persistent state, menu, migration, or browser storage.
+    - id: preserve-removed-runtime-boundary
+      title: Preserve the removed runtime developer-tools boundary
+      description: Page configuration remains a presentation overlay over compiled application capabilities.
+      priority: must
+      actor: security-reviewer
+      module: presentation-contract
+      rules:
+        - No profile creates or changes an entity, database schema, API, route, permission, workflow, component implementation, or executable template.
+        - New business fields and capabilities continue through AdminModule specifications, deterministic generation, migrations, code review, and tests.
+        - Later persistence must use draft, validation, ETag publish, immutable history, rollback, definition-drift reporting, and recovery-mode controls before production adoption.
+        - Authentication, authorization, configuration, release, and recovery pages remain excluded until an explicit security review approves each page.
+  constraints:
+    - id: compiled-capability-boundary
+      type: security
+      statement: Untrusted presentation documents may reference only identifiers present in the exact compiled capability definition selected by page key and definition hash.
+    - id: authorization-applied-last
+      type: security
+      statement: Trusted backend permission requirements are intersected after every presentation layer and cannot be edited, inherited away, or weakened by profile data.
+    - id: no-executable-configuration
+      type: security
+      statement: The contract admits no scripts, expressions, HTML, SQL, imports, network transport definitions, component loading, or other executable payloads.
+    - id: generated-source-ownership
+      type: compatibility
+      statement: P0 does not hand-edit generated Supplier files; a later production projection must originate in AdminModule specifications and deterministic generators.
+    - id: definition-drift-fails-closed
+      type: compatibility
+      statement: A profile bound to another capability hash is rejected as one unit and the resolver retains the latest lower valid presentation.
+    - id: p0-has-no-runtime-side-effects
+      type: operations
+      statement: P0 adds no production route, persistence, API call, browser storage, migration, menu entry, release artifact, or configuration mutation.
+    - id: bounded-profile-size
+      type: performance
+      statement: Schema collections, text, page sizes, sort keys, fields, actions, and condition groups are explicitly bounded before future persistence is introduced.
+    - id: localized-visible-text
+      type: ux
+      statement: Editable page, field, placeholder, help, action, and confirmation text is plain localized zh-CN and en-US data with no markup execution.
+  acceptance:
+    - id: trusted-capability-tests
+      requirement: define-trusted-capabilities
+      statement: Contract tests reject duplicate identifiers and invalid trusted defaults and prove resolution leaves the frozen Supplier definition unchanged.
+      level: contract
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: test
+          value: web/antd-v6/src/shared/presentation/contract.test.ts
+    - id: strict-schema-tests
+      requirement: constrain-presentation-documents
+      statement: The schema parses as draft 2020-12, keeps every object closed, requires exact identity and hash metadata, and contains none of the executable or transport property names.
+      level: contract
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: path
+          value: .mss/schemas/admin-page-presentation.schema.json
+        - type: test
+          value: internal/mss/spec/presentation_schema_test.go
+    - id: layered-resolution-tests
+      requirement: resolve-layered-presentation
+      statement: Unit tests prove code, application, role, and user precedence plus whole-layer rejection and lower-layer fallback for drift and invalid references.
+      level: unit
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: test
+          value: web/antd-v6/src/shared/presentation/contract.test.ts
+    - id: authorization-intersection-tests
+      requirement: preserve-authorization-boundary
+      statement: Unit tests prove an overlay cannot make an unauthorized data source or action visible and permission denial produces no visible actions.
+      level: security
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: test
+          value: web/antd-v6/src/shared/presentation/contract.test.ts
+    - id: supplier-prototype-tests
+      requirement: prove-supplier-reference
+      statement: The compact Supplier profile produces the expected renderer-ready list and remains absent from production route registration.
+      level: contract
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: test
+          value: web/antd-v6/src/shared/presentation/supplier.prototype.test.ts
+        - type: path
+          value: web/antd-v6/src/shared/presentation/supplier.prototype.ts
+    - id: removed-boundary-review
+      requirement: preserve-removed-runtime-boundary
+      statement: Architecture review and schema tests prove P0 cannot create runtime models, APIs, routes, permissions, executable templates, or component implementations.
+      level: security
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: path
+          value: docs/adr/2026-08-24-governed-admin-presentation-configuration.md
+        - type: test
+          value: internal/mss/spec/presentation_schema_test.go
+    - id: p0-changed-verification
+      statement: Feature validation, focused Go and frontend contract tests, frontend lint, and documentation build complete without tracked-file drift.
+      level: integration
+      phase: checkpoint
+      required: true
+      evidence:
+        - type: command
+          value: go run ./cmd/mss spec validate .mss/features/admin-presentation-configuration.yaml --format json
+        - type: command
+          value: go test ./internal/mss/spec
+        - type: command
+          value: corepack pnpm@10.34.5 --dir web/antd-v6 test src/shared/presentation
+        - type: command
+          value: corepack pnpm@10.34.5 --dir web/antd-v6 lint
+        - type: command
+          value: corepack pnpm@9.15.9 --dir docs build
+  risks:
+    - id: presentation-becomes-low-code
+      description: Pressure for more flexibility could add arbitrary data sources, expressions, components, or schema mutation and recreate the removed runtime developer tools.
+      severity: critical
+      mitigation: Keep the schema data-only, require registry references and definition hashes, and route new capabilities through specifications, generation, review, and tests.
+    - id: profile-expands-authority
+      description: A display profile could accidentally bypass permission checks by adding an action or selecting a protected data source.
+      severity: critical
+      mitigation: Store permission requirements only in trusted capability code and intersect them after all overlays with backend enforcement remaining authoritative.
+    - id: capability-profile-drift
+      description: A module upgrade can remove or reinterpret identifiers while an older profile still appears structurally valid.
+      severity: high
+      mitigation: Bind every profile to a sha256 definition hash, reject the complete stale layer, expose diagnostics, and keep a safe compiled default.
+    - id: invalid-form-configuration
+      description: Hiding a required field or choosing an incompatible component can make create or edit flows unusable.
+      severity: high
+      mitigation: Declare required fields and allowed components per surface and reject an unsafe profile before it reaches the renderer.
+    - id: core-recovery-lockout
+      description: Configuring authorization, configuration, or recovery pages too early could remove the controls needed to repair a broken profile.
+      severity: high
+      mitigation: Exclude critical pages in early phases and require a non-configurable recovery mode before any later opt-in.
+  validation:
+    changed: go run ./cmd/mss verify --changed
+    all: go run ./cmd/mss verify --all
+    custom:
+      - go run ./cmd/mss spec validate .mss/features/admin-presentation-configuration.yaml --format json
+      - go test ./internal/mss/spec
+      - corepack pnpm@10.34.5 --dir web/antd-v6 test src/shared/presentation
+      - corepack pnpm@10.34.5 --dir web/antd-v6 lint
+      - corepack pnpm@9.15.9 --dir docs build
+  rollout:
+    strategy: shadow
+    migration: >-
+      P0 is a source-only contract and test prototype. It has no database migration, API, route,
+      production import, browser storage, or generated-file replacement. P1 may add persistence only
+      after a separate reviewed specification defines draft, ETag publish, immutable history, rollback,
+      authorization, audit, cache, definition drift, and recovery behavior.
+    rollback: >-
+      Revert the P0 source commit. Because the prototype is not routed or persisted and creates no
+      external contract or data, rollback removes only the planned capability, schema, ADR, resolver,
+      Supplier fixture, and their tests.

--- a/.mss/release-qualification.json
+++ b/.mss/release-qualification.json
@@ -38,6 +38,10 @@
       "reason": "carry-forward: accepted backend authorization and negative tests remain part of the complete Admin suite selected by v1.3.2."
     },
     {
+      "path": ".mss/features/admin-presentation-configuration.yaml",
+      "reason": "carry-forward: planned post-v1.3.2 presentation-configuration P0 contracts are intentionally outside the immutable v1.3.2 release evidence and must be selected by a future release qualification before production adoption."
+    },
+    {
       "path": ".mss/features/admin-runtime-tools-removal-monitoring.yaml",
       "reason": "carry-forward: the removed runtime developer-tool boundary remains enforced and is not reintroduced by v1.3.2."
     },

--- a/.mss/schemas/admin-page-presentation.schema.json
+++ b/.mss/schemas/admin-page-presentation.schema.json
@@ -1,0 +1,258 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mss-boot.io/schemas/admin-page-presentation.v1alpha1.json",
+  "title": "MSS Admin page presentation profile",
+  "description": "A sparse, data-only presentation overlay that may reference only capabilities compiled into the Admin application.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "mss.io/v1alpha1"},
+    "kind": {"const": "AdminPagePresentation"},
+    "metadata": {"$ref": "#/$defs/metadata"},
+    "spec": {"$ref": "#/$defs/spec"}
+  },
+  "$comment": "JSON Schema validates document shape. The runtime registry must additionally reject unknown page, field, component, data-source, and action identifiers and must apply backend authorization after all overlays.",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$",
+      "minLength": 2,
+      "maxLength": 120
+    },
+    "definitionHash": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "localizedText": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "zh-CN": {"type": "string", "minLength": 1, "maxLength": 200},
+        "en-US": {"type": "string", "minLength": 1, "maxLength": 200}
+      }
+    },
+    "applicationScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {"const": "application"}
+      }
+    },
+    "roleScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "subject"],
+      "properties": {
+        "kind": {"const": "role"},
+        "subject": {"$ref": "#/$defs/identifier"}
+      }
+    },
+    "userScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "subject"],
+      "properties": {
+        "kind": {"const": "user"},
+        "subject": {"type": "string", "minLength": 1, "maxLength": 160}
+      }
+    },
+    "scope": {
+      "oneOf": [
+        {"$ref": "#/$defs/applicationScope"},
+        {"$ref": "#/$defs/roleScope"},
+        {"$ref": "#/$defs/userScope"}
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "pageKey", "definitionHash", "scope"],
+      "properties": {
+        "name": {"$ref": "#/$defs/identifier"},
+        "pageKey": {"$ref": "#/$defs/identifier"},
+        "description": {"type": "string", "maxLength": 500},
+        "definitionHash": {"$ref": "#/$defs/definitionHash"},
+        "scope": {"$ref": "#/$defs/scope"}
+      }
+    },
+    "scalar": {
+      "type": ["string", "number", "boolean", "null"]
+    },
+    "conditionValue": {
+      "oneOf": [
+        {"$ref": "#/$defs/scalar"},
+        {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 50,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/scalar"}
+        }
+      ]
+    },
+    "predicate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "operator"],
+      "properties": {
+        "field": {"$ref": "#/$defs/identifier"},
+        "operator": {
+          "type": "string",
+          "enum": ["eq", "neq", "in", "not-in", "exists", "not-exists", "gt", "gte", "lt", "lte"]
+        },
+        "value": {"$ref": "#/$defs/conditionValue"}
+      }
+    },
+    "allCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["all"],
+      "properties": {
+        "all": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {"$ref": "#/$defs/condition"}
+        }
+      }
+    },
+    "anyCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["any"],
+      "properties": {
+        "any": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {"$ref": "#/$defs/condition"}
+        }
+      }
+    },
+    "notCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["not"],
+      "properties": {
+        "not": {"$ref": "#/$defs/condition"}
+      }
+    },
+    "condition": {
+      "oneOf": [
+        {"$ref": "#/$defs/predicate"},
+        {"$ref": "#/$defs/allCondition"},
+        {"$ref": "#/$defs/anyCondition"},
+        {"$ref": "#/$defs/notCondition"}
+      ]
+    },
+    "fieldPatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field"],
+      "properties": {
+        "field": {"$ref": "#/$defs/identifier"},
+        "label": {"$ref": "#/$defs/localizedText"},
+        "component": {"$ref": "#/$defs/identifier"},
+        "order": {"type": "integer", "minimum": 0, "maximum": 10000},
+        "hidden": {"type": "boolean"},
+        "width": {"type": "integer", "minimum": 60, "maximum": 1200},
+        "span": {"type": "integer", "minimum": 1, "maximum": 24},
+        "placeholder": {"$ref": "#/$defs/localizedText"},
+        "help": {"$ref": "#/$defs/localizedText"},
+        "visibleWhen": {"$ref": "#/$defs/condition"}
+      }
+    },
+    "fieldPatches": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {"$ref": "#/$defs/fieldPatch"}
+    },
+    "sort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "direction"],
+      "properties": {
+        "field": {"$ref": "#/$defs/identifier"},
+        "direction": {"type": "string", "enum": ["asc", "desc"]}
+      }
+    },
+    "list": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "columns": {"$ref": "#/$defs/fieldPatches"},
+        "density": {"type": "string", "enum": ["compact", "middle", "large"]},
+        "pageSize": {"type": "integer", "minimum": 1, "maximum": 200},
+        "defaultSort": {
+          "type": "array",
+          "maxItems": 3,
+          "uniqueItems": true,
+          "items": {"$ref": "#/$defs/sort"}
+        }
+      }
+    },
+    "search": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "fields": {"$ref": "#/$defs/fieldPatches"},
+        "collapsedByDefault": {"type": "boolean"}
+      }
+    },
+    "form": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "fields": {"$ref": "#/$defs/fieldPatches"},
+        "columns": {"type": "integer", "minimum": 1, "maximum": 4}
+      }
+    },
+    "detail": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "fields": {"$ref": "#/$defs/fieldPatches"},
+        "columns": {"type": "integer", "minimum": 1, "maximum": 4}
+      }
+    },
+    "actionPatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action"],
+      "properties": {
+        "action": {"$ref": "#/$defs/identifier"},
+        "label": {"$ref": "#/$defs/localizedText"},
+        "placement": {"type": "string", "enum": ["toolbar", "row", "form", "detail"]},
+        "order": {"type": "integer", "minimum": 0, "maximum": 10000},
+        "hidden": {"type": "boolean"},
+        "confirm": {"$ref": "#/$defs/localizedText"},
+        "visibleWhen": {"$ref": "#/$defs/condition"}
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "title": {"$ref": "#/$defs/localizedText"},
+        "dataSource": {"$ref": "#/$defs/identifier"},
+        "list": {"$ref": "#/$defs/list"},
+        "search": {"$ref": "#/$defs/search"},
+        "form": {"$ref": "#/$defs/form"},
+        "detail": {"$ref": "#/$defs/detail"},
+        "actions": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {"$ref": "#/$defs/actionPatch"}
+        }
+      }
+    }
+  }
+}

--- a/docs/adr/2026-08-24-governed-admin-presentation-configuration.md
+++ b/docs/adr/2026-08-24-governed-admin-presentation-configuration.md
@@ -1,0 +1,192 @@
+# ADR: Governed Admin page presentation configuration
+
+- Status: Proposed; P0 contract and non-production prototype
+- Date: 2026-08-24
+- Owners: Admin platform, frontend, security, agent infrastructure
+- Feature contract: `.mss/features/admin-presentation-configuration.yaml`
+- Profile schema: `.mss/schemas/admin-page-presentation.schema.json`
+
+## Context
+
+The complete Admin backend and Ant Design 6 frontend are now distributed independently from business
+projects. That solves source ownership and upgradeability, but it does not make routine page presentation
+changes operational. Columns, search controls, form layout, detail layout, labels, density, and action
+placement are still compiled into each React page. A harmless display change therefore requires a source
+change, build, review, and release.
+
+The repository deliberately removed runtime dynamic models, virtual CRUD, and browser-facing template or
+code generation. It also requires routes and business registration to remain compile-time explicit, with
+backend authorization authoritative. Page configuration must strengthen the product without crossing any
+of those boundaries.
+
+The useful target is therefore not “arbitrary pages without code.” The useful and defensible target is:
+
+> Within capabilities already compiled and authorized by the Admin distribution, routine presentation
+> choices are data; creating a new capability remains specification, generation, code, migration, review,
+> and release work.
+
+## Decision
+
+Adopt a two-sided contract and a deterministic resolver.
+
+### Trusted capability definitions
+
+Maintained code or deterministic module generation emits a `PageCapabilityDefinition` for each supported
+page. It is trusted application code and declares:
+
+- a stable page key, definition version, and SHA-256 definition hash;
+- registered fields and the surfaces on which each field is valid;
+- value type, required state, sorting and filtering support;
+- allowed component identifiers for each field;
+- registered data sources and their backend permission requirements;
+- registered actions, placements, destructive semantics, and backend permission requirements;
+- a complete safe default presentation.
+
+No editable document may redefine those facts. The definition hash covers the compatibility surface, not
+the user's presentation choices, and lets the runtime identify profile drift after a module upgrade.
+
+### Untrusted sparse presentation profiles
+
+An `AdminPagePresentation` document is untrusted data and is validated twice:
+
+1. JSON Schema validates exact version, shape, bounds, and closed objects.
+2. The selected capability definition validates every page, field, component, data-source, action, sort,
+   filter, surface, required-field, and condition reference.
+
+The profile can change only localized plain text, visibility, ordering, component selection from an
+allowlist, width, span, table density, page size, default sorting, layout columns, action placement, and a
+bounded declarative visibility condition tree. It cannot contain permissions, routes, URLs, HTTP methods,
+headers, HTML, JavaScript, expressions, SQL, imports, component implementations, plugins, or templates.
+
+The profile metadata binds the document to one exact page key and definition hash and identifies its
+application, role, or user scope. Server revision, draft, publish, and audit metadata will live in a
+separate persistence envelope in P1 rather than changing the portable profile document.
+
+### Resolution and security order
+
+The resolver applies sparse layers in this order:
+
+```text
+compiled default < application profile < role profile < current-user profile
+                                              |
+                                              v
+                            trusted permission intersection last
+```
+
+At most one already-selected profile participates at each layer. Resolving multiple user roles into one
+deterministic role profile is a future server-side policy decision; the browser does not invent a role
+merge order.
+
+Missing values inherit from the lower layer and explicit `false` remains an explicit value. Each layer is
+validated as a unit against the current definition and the current lower-layer result. A page-key or hash
+mismatch, unknown identifier, duplicate reference, incompatible component, unsupported sort/filter, or
+attempt to hide a required form field rejects that complete layer. Lower valid layers remain available and
+the resolver returns structured diagnostics.
+
+After all overlays, the resolver intersects the selected data source and every action with permissions
+stored in the trusted capability definition. An editable profile cannot supply or remove a permission. If
+the data-source permission is absent, the renderer receives a permission-denied model and no actions.
+This browser check improves experience only; backend authorization remains authoritative for every request.
+
+### Renderer boundary
+
+The resolver outputs a framework-neutral render model: localized title, authorized data-source identifier,
+ordered visible list/search/form/detail fields, allowed component identifiers, actions, and page state. A
+future `ConfigurablePage` maps only registered component identifiers to imported React components. It never
+imports a path supplied by configuration.
+
+Two later adoption modes are allowed:
+
+1. Overlay an existing compiled page while retaining its route and data adapter.
+2. Create another view of an existing registered resource beneath one compiled route such as
+   `/views/:viewKey`.
+
+Neither mode creates a new resource, backend endpoint, permission, route implementation, or component.
+
+## P0 scope
+
+P0 delivers only:
+
+- the FeatureSpec and this decision;
+- the strict `mss.io/v1alpha1` JSON Schema;
+- TypeScript capability, profile, resolver, validator, and render-model contracts;
+- a non-production Supplier capability and compact application profile;
+- contract tests for precedence, drift, reference safety, required-field safety, immutability, and
+  authorization-last behavior;
+- a planned capability-catalog entry.
+
+The Supplier prototype is not registered in the production route tree, does not replace generated output,
+does not call an API, and does not persist data. P0 therefore requires no migration or runtime rollback.
+
+## Security invariants
+
+- Configuration is data-only and objects are closed by schema.
+- Only exact compiled identifiers are accepted.
+- Definition drift rejects the whole layer; it is never partially “best effort.”
+- Permission requirements exist only in trusted definitions and are applied last.
+- Visibility is never treated as authorization.
+- Required form inputs cannot be hidden by a profile.
+- Conditions read registered record fields and use a bounded operator tree; they do not execute code.
+- Localized text is plain text. Renderers must not use raw HTML injection.
+- Authentication, authorization, application configuration, release, and recovery pages remain excluded
+  until separately qualified.
+- A later production editor must include an unconfigurable recovery path.
+
+## Compatibility and generation
+
+Stable identifiers are compatibility surfaces. Generator changes that rename or remove an identifier must
+change the definition hash and report affected profiles. A later upgrade workflow may offer a reviewed
+profile migration, but it must never silently reinterpret a stale identifier.
+
+Generated business pages ultimately need generated capability definitions sourced from the same
+`AdminModule` specification as backend, API, permissions, routes, frontend, tests, and documentation.
+P0 keeps Supplier in a handwritten prototype fixture to prove the contract without hand-editing generated
+files. Production adoption requires updating the generator source and proving deterministic, two-run
+idempotent output.
+
+## Persistence and publication roadmap
+
+P1 may add an authoritative backend resource only after a dedicated design covers:
+
+- profile ownership and scoped read/write permissions;
+- draft validation and preview;
+- strong ETag conditional writes;
+- atomic publish with immutable revision history;
+- rollback by publishing a prior valid document as a new revision;
+- redacted audit events and metrics;
+- definition-drift diagnostics and a compiled-default fallback;
+- database authority, bounded cache behavior, and outage semantics;
+- an unconfigurable recovery mode.
+
+P2 can project capability definitions from generated business modules and adopt Supplier behind an explicit
+feature gate. P3 can add a visual editor and additional views of registered resources. P4 can evaluate
+selected core pages after recovery and security evidence. No phase is authorized by this P0 ADR alone.
+
+## Rejected alternatives
+
+- **Store arbitrary React or JSON component trees:** couples persisted data to implementation details and
+  enables an unsafe component-loading surface.
+- **Allow URLs, methods, headers, GraphQL, or SQL in a profile:** turns presentation configuration into a
+  data-access and credential-exfiltration mechanism.
+- **Allow JavaScript or expression evaluation:** recreates executable browser templates and makes review,
+  CSP, reproducibility, and authorization reasoning unreliable.
+- **Make permissions configurable:** lets a presentation operator mutate authority and conflicts with
+  backend-authoritative RBAC.
+- **Use menu component strings as dynamic imports:** bypasses the compiled route registry and package export
+  contract.
+- **Revive runtime dynamic models or virtual CRUD:** violates the explicit removed developer-tools boundary.
+- **Fork one bespoke settings format per page:** prevents deterministic validation, publishing, upgrades,
+  and a generic renderer.
+
+## Consequences
+
+Routine display choices can become configurable while the application keeps a small, auditable attack
+surface. New capabilities still require code and release work, which is an intentional product boundary.
+The platform must maintain stable identifiers, registry validation, compatibility hashes, and renderer
+components as public contracts.
+
+P0 completion is measurable: the feature validates, the schema safety tests pass, the focused frontend
+tests produce the expected Supplier render model, lint and documentation build pass, no production route
+imports the prototype, and the tracked worktree remains clean after verification. The next executable step
+after P0 review is a separate P1 FeatureSpec for draft, publish, history, rollback, and recovery persistence;
+it is not to wire the prototype directly into production.

--- a/internal/mss/spec/presentation_schema_test.go
+++ b/internal/mss/spec/presentation_schema_test.go
@@ -1,0 +1,172 @@
+package spec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestAdminPagePresentationSchemaIsVersionedClosedAndDataOnly(t *testing.T) {
+	schema := readAdminPagePresentationSchema(t)
+	if schema["$schema"] != "https://json-schema.org/draft/2020-12/schema" {
+		t.Fatalf("unexpected JSON Schema dialect: %#v", schema["$schema"])
+	}
+	if schema["$id"] != "https://mss-boot.io/schemas/admin-page-presentation.v1alpha1.json" {
+		t.Fatalf("unexpected schema id: %#v", schema["$id"])
+	}
+	properties := jsonObject(t, schema["properties"], "properties")
+	if jsonObject(t, properties["apiVersion"], "properties.apiVersion")["const"] != "mss.io/v1alpha1" {
+		t.Fatal("apiVersion must be fixed to mss.io/v1alpha1")
+	}
+	if jsonObject(t, properties["kind"], "properties.kind")["const"] != "AdminPagePresentation" {
+		t.Fatal("kind must be fixed to AdminPagePresentation")
+	}
+
+	forbidden := map[string]bool{
+		"permission": true, "permissions": true, "route": true, "url": true,
+		"method": true, "headers": true, "html": true, "script": true,
+		"expression": true, "sql": true, "import": true, "componentImport": true,
+		"plugin": true, "template": true,
+	}
+	walkPresentationSchema(t, schema, "$", forbidden)
+}
+
+func TestAdminPagePresentationSchemaBindsProfilesToCompiledCapabilities(t *testing.T) {
+	schema := readAdminPagePresentationSchema(t)
+	definitions := jsonObject(t, schema["$defs"], "$defs")
+	metadata := jsonObject(t, definitions["metadata"], "$defs.metadata")
+	required := jsonStrings(t, metadata["required"], "$defs.metadata.required")
+	for _, field := range []string{"name", "pageKey", "definitionHash", "scope"} {
+		if !slices.Contains(required, field) {
+			t.Fatalf("metadata does not require %q: %#v", field, required)
+		}
+	}
+	hash := jsonObject(t, definitions["definitionHash"], "$defs.definitionHash")
+	if hash["pattern"] != "^sha256:[0-9a-f]{64}$" {
+		t.Fatalf("definition hash is not an exact SHA-256 identity: %#v", hash["pattern"])
+	}
+
+	specification := jsonObject(t, definitions["spec"], "$defs.spec")
+	specificationProperties := jsonObject(t, specification["properties"], "$defs.spec.properties")
+	for _, reference := range []string{"dataSource", "list", "search", "form", "detail", "actions"} {
+		if _, exists := specificationProperties[reference]; !exists {
+			t.Fatalf("presentation spec is missing %q", reference)
+		}
+	}
+
+	fieldPatch := jsonObject(t, definitions["fieldPatch"], "$defs.fieldPatch")
+	fieldProperties := jsonObject(t, fieldPatch["properties"], "$defs.fieldPatch.properties")
+	if _, exists := fieldProperties["field"]; !exists {
+		t.Fatal("field patches must use a stable field reference")
+	}
+	if _, exists := fieldProperties["component"]; !exists {
+		t.Fatal("field patches must use a registered component reference")
+	}
+	actionPatch := jsonObject(t, definitions["actionPatch"], "$defs.actionPatch")
+	actionProperties := jsonObject(t, actionPatch["properties"], "$defs.actionPatch.properties")
+	if _, exists := actionProperties["action"]; !exists {
+		t.Fatal("action patches must use a stable action reference")
+	}
+}
+
+func TestAdminPagePresentationConditionDSLIsBoundedAndNonExecutable(t *testing.T) {
+	schema := readAdminPagePresentationSchema(t)
+	definitions := jsonObject(t, schema["$defs"], "$defs")
+	predicate := jsonObject(t, definitions["predicate"], "$defs.predicate")
+	properties := jsonObject(t, predicate["properties"], "$defs.predicate.properties")
+	operator := jsonObject(t, properties["operator"], "$defs.predicate.properties.operator")
+	operators := jsonStrings(t, operator["enum"], "$defs.predicate.properties.operator.enum")
+	expected := []string{"eq", "neq", "in", "not-in", "exists", "not-exists", "gt", "gte", "lt", "lte"}
+	if !slices.Equal(operators, expected) {
+		t.Fatalf("unexpected condition operators: %#v", operators)
+	}
+
+	for _, groupName := range []string{"allCondition", "anyCondition"} {
+		group := jsonObject(t, definitions[groupName], "$defs."+groupName)
+		groupProperties := jsonObject(t, group["properties"], "$defs."+groupName+".properties")
+		key := "all"
+		if groupName == "anyCondition" {
+			key = "any"
+		}
+		items := jsonObject(t, groupProperties[key], "$defs."+groupName+".properties."+key)
+		if items["maxItems"] != float64(20) {
+			t.Fatalf("%s does not bound group size: %#v", groupName, items["maxItems"])
+		}
+	}
+}
+
+func walkPresentationSchema(t *testing.T, value any, path string, forbidden map[string]bool) {
+	t.Helper()
+	switch current := value.(type) {
+	case map[string]any:
+		if current["type"] == "object" && current["additionalProperties"] != false {
+			t.Errorf("object schema %s is not closed with additionalProperties=false", path)
+		}
+		if rawProperties, exists := current["properties"]; exists {
+			properties := jsonObject(t, rawProperties, path+".properties")
+			for name := range properties {
+				if forbidden[name] {
+					t.Errorf("schema exposes forbidden executable or authority property %s.%s", path, name)
+				}
+			}
+		}
+		for key, nested := range current {
+			walkPresentationSchema(t, nested, fmt.Sprintf("%s.%s", path, key), forbidden)
+		}
+	case []any:
+		for index, nested := range current {
+			walkPresentationSchema(t, nested, fmt.Sprintf("%s[%d]", path, index), forbidden)
+		}
+	}
+}
+
+func readAdminPagePresentationSchema(t *testing.T) map[string]any {
+	t.Helper()
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve presentation schema test source path")
+	}
+	path := filepath.Clean(filepath.Join(
+		filepath.Dir(sourceFile), "..", "..", "..", ".mss", "schemas",
+		"admin-page-presentation.schema.json",
+	))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Admin page presentation JSON Schema: %v", err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("parse Admin page presentation JSON Schema: %v", err)
+	}
+	return schema
+}
+
+func jsonObject(t *testing.T, value any, path string) map[string]any {
+	t.Helper()
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object: %#v", path, value)
+	}
+	return object
+}
+
+func jsonStrings(t *testing.T, value any, path string) []string {
+	t.Helper()
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("%s is not an array: %#v", path, value)
+	}
+	values := make([]string, 0, len(items))
+	for index, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			t.Fatalf("%s[%d] is not a string: %#v", path, index, item)
+		}
+		values = append(values, text)
+	}
+	return values
+}

--- a/web/antd-v6/src/shared/presentation/contract.test.ts
+++ b/web/antd-v6/src/shared/presentation/contract.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADMIN_PRESENTATION_API_VERSION,
+  ADMIN_PRESENTATION_KIND,
+  type AdminPagePresentationProfile,
+  buildPageRenderModel,
+  type PagePresentationSpec,
+  resolvePagePresentation,
+  validatePageCapabilityDefinition,
+  validatePagePresentationProfile,
+} from './contract';
+import { supplierPresentationCapability } from './supplier.prototype';
+
+const allPermissions = new Set([
+  '/suppliers',
+  '/suppliers/permissions/list',
+  '/suppliers/permissions/read',
+  '/suppliers/permissions/create',
+  '/suppliers/permissions/update',
+  '/suppliers/permissions/delete',
+  '/suppliers/permissions/export',
+]);
+
+function profile(
+  name: string,
+  scope: AdminPagePresentationProfile['metadata']['scope'],
+  spec: PagePresentationSpec,
+): AdminPagePresentationProfile {
+  return {
+    apiVersion: ADMIN_PRESENTATION_API_VERSION,
+    kind: ADMIN_PRESENTATION_KIND,
+    metadata: {
+      name,
+      pageKey: supplierPresentationCapability.pageKey,
+      definitionHash: supplierPresentationCapability.definitionHash,
+      scope,
+    },
+    spec,
+  };
+}
+
+describe('Admin page presentation contract', () => {
+  it('accepts the trusted Supplier definition and never mutates it while resolving', () => {
+    expect(validatePageCapabilityDefinition(supplierPresentationCapability)).toEqual([]);
+    const before = JSON.stringify(supplierPresentationCapability);
+
+    resolvePagePresentation(
+      supplierPresentationCapability,
+      {
+        application: profile(
+          'application-layout',
+          { kind: 'application' },
+          {
+            list: { columns: [{ field: 'country', hidden: true }] },
+          },
+        ),
+      },
+      allPermissions,
+    );
+
+    expect(JSON.stringify(supplierPresentationCapability)).toBe(before);
+  });
+
+  it('resolves code, application, role, and user values in deterministic order', () => {
+    const application = profile(
+      'application-layout',
+      { kind: 'application' },
+      {
+        title: { 'zh-CN': '应用供应商' },
+        list: {
+          density: 'compact',
+          columns: [{ field: 'country', hidden: true }],
+        },
+      },
+    );
+    const role = profile(
+      'procurement-layout',
+      { kind: 'role', subject: 'procurement' },
+      {
+        title: { 'en-US': 'Procurement suppliers' },
+        list: { columns: [{ field: 'country', hidden: false, order: 15 }] },
+      },
+    );
+    const user = profile(
+      'operator-layout',
+      { kind: 'user', subject: 'operator-1' },
+      {
+        title: { 'zh-CN': '我的供应商' },
+        list: { columns: [{ field: 'country', label: { 'zh-CN': '所在地区' } }] },
+      },
+    );
+
+    const resolution = resolvePagePresentation(
+      supplierPresentationCapability,
+      { application, role, user },
+      allPermissions,
+    );
+    const model = buildPageRenderModel(supplierPresentationCapability, resolution, 'zh-CN');
+
+    expect(resolution.appliedLayers).toEqual(['application', 'role', 'user']);
+    expect(resolution.rejectedLayers).toEqual([]);
+    expect(model.title).toBe('我的供应商');
+    expect(model.list.density).toBe('compact');
+    expect(model.list.columns[1]).toMatchObject({ field: 'country', label: '所在地区' });
+  });
+
+  it('rejects a stale profile as a whole and keeps the compiled fallback', () => {
+    const stale = profile(
+      'stale-layout',
+      { kind: 'application' },
+      {
+        list: { columns: [{ field: 'country', hidden: true }] },
+      },
+    );
+    stale.metadata.definitionHash = `sha256:${'f'.repeat(64)}`;
+
+    const resolution = resolvePagePresentation(
+      supplierPresentationCapability,
+      { application: stale },
+      allPermissions,
+    );
+    const model = buildPageRenderModel(supplierPresentationCapability, resolution, 'en-US');
+
+    expect(resolution.appliedLayers).toEqual([]);
+    expect(resolution.rejectedLayers[0]?.issues).toContainEqual(
+      expect.objectContaining({ code: 'definition-hash-mismatch' }),
+    );
+    expect(model.list.columns.map((field) => field.field)).toContain('country');
+  });
+
+  it('rejects unknown references, forbidden transport keys, and unsafe required-field hiding', () => {
+    const invalid = profile(
+      'invalid-layout',
+      { kind: 'application' },
+      {
+        list: {
+          columns: [{ field: 'invented', component: 'remote-widget' }],
+        },
+        form: {
+          fields: [{ field: 'code', hidden: true }],
+        },
+      },
+    );
+    Object.assign(invalid.spec, { url: 'https://example.test/data', method: 'GET' });
+
+    const issues = validatePagePresentationProfile(supplierPresentationCapability, invalid);
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'unknown-field' }),
+        expect.objectContaining({ code: 'required-form-field-hidden' }),
+        expect.objectContaining({ code: 'forbidden-profile-key', path: '$.spec.url' }),
+        expect.objectContaining({ code: 'forbidden-profile-key', path: '$.spec.method' }),
+      ]),
+    );
+
+    const resolution = resolvePagePresentation(
+      supplierPresentationCapability,
+      { application: invalid },
+      allPermissions,
+    );
+    expect(resolution.appliedLayers).toEqual([]);
+    expect(resolution.rejectedLayers).toHaveLength(1);
+  });
+
+  it('intersects trusted action permissions after every valid presentation overlay', () => {
+    const visibleActions = profile(
+      'visible-actions',
+      { kind: 'application' },
+      {
+        actions: [
+          { action: 'supplier.create', hidden: false },
+          { action: 'supplier.delete', hidden: false },
+          { action: 'supplier.export', hidden: false },
+        ],
+      },
+    );
+    const resolution = resolvePagePresentation(
+      supplierPresentationCapability,
+      { application: visibleActions },
+      new Set(['/suppliers', '/suppliers/permissions/list', '/suppliers/permissions/read']),
+    );
+    const model = buildPageRenderModel(supplierPresentationCapability, resolution, 'en-US');
+
+    expect(model.status).toBe('ready');
+    expect(model.actions.map((action) => action.action)).toEqual(['supplier.read']);
+    expect(resolution.removedActionIds).toEqual([
+      'supplier.create',
+      'supplier.delete',
+      'supplier.export',
+      'supplier.update',
+    ]);
+  });
+
+  it('returns a permission-denied model with no data source or actions', () => {
+    const resolution = resolvePagePresentation(
+      supplierPresentationCapability,
+      {},
+      new Set(['/suppliers/permissions/create', '/suppliers/permissions/delete']),
+    );
+    const model = buildPageRenderModel(supplierPresentationCapability, resolution, 'zh-CN');
+
+    expect(model.status).toBe('permission-denied');
+    expect(model.dataSource).toBeUndefined();
+    expect(model.actions).toEqual([]);
+  });
+
+  it('fails closed when trusted capability identifiers are duplicated', () => {
+    const firstComponent = supplierPresentationCapability.components[0];
+    if (!firstComponent) throw new Error('Supplier needs at least one registered component');
+    const invalidCapability = {
+      ...supplierPresentationCapability,
+      components: [...supplierPresentationCapability.components, firstComponent],
+    };
+
+    expect(() => resolvePagePresentation(invalidCapability, {}, allPermissions)).toThrow(
+      'Invalid page capability supplier.list',
+    );
+  });
+});

--- a/web/antd-v6/src/shared/presentation/contract.ts
+++ b/web/antd-v6/src/shared/presentation/contract.ts
@@ -1,0 +1,1168 @@
+export const ADMIN_PRESENTATION_API_VERSION = 'mss.io/v1alpha1' as const;
+export const ADMIN_PRESENTATION_KIND = 'AdminPagePresentation' as const;
+
+export type AdminLocale = 'zh-CN' | 'en-US';
+export type PresentationSurface = 'list' | 'search' | 'form' | 'detail';
+export type PresentationLayer = 'application' | 'role' | 'user';
+export type PresentationDensity = 'compact' | 'middle' | 'large';
+export type PresentationActionPlacement = 'toolbar' | 'row' | 'form' | 'detail';
+export type PresentationSortDirection = 'asc' | 'desc';
+export type PresentationValueType = 'string' | 'number' | 'boolean' | 'enum' | 'date' | 'date-time';
+
+export interface LocalizedText {
+  'zh-CN'?: string;
+  'en-US'?: string;
+}
+
+export type PresentationScalar = string | number | boolean | null;
+export type PresentationPredicateOperator =
+  | 'eq'
+  | 'neq'
+  | 'in'
+  | 'not-in'
+  | 'exists'
+  | 'not-exists'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte';
+
+export type PresentationCondition =
+  | {
+      field: string;
+      operator: PresentationPredicateOperator;
+      value?: PresentationScalar | readonly PresentationScalar[];
+    }
+  | { all: readonly PresentationCondition[] }
+  | { any: readonly PresentationCondition[] }
+  | { not: PresentationCondition };
+
+export interface PageCapabilityField {
+  id: string;
+  label: LocalizedText;
+  valueType: PresentationValueType;
+  required: boolean;
+  sortable: boolean;
+  filterable: boolean;
+  surfaces: readonly PresentationSurface[];
+  components: readonly string[];
+}
+
+export interface PageCapabilityComponent {
+  id: string;
+}
+
+export interface PageCapabilityDataSource {
+  id: string;
+  requiredPermissions: readonly string[];
+}
+
+export interface PageCapabilityAction {
+  id: string;
+  requiredPermissions: readonly string[];
+  placements: readonly PresentationActionPlacement[];
+  destructive?: boolean;
+}
+
+export interface PageFieldPresentation {
+  field: string;
+  label?: LocalizedText;
+  component: string;
+  order: number;
+  hidden: boolean;
+  width?: number;
+  span?: number;
+  placeholder?: LocalizedText;
+  help?: LocalizedText;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageFieldPresentationPatch {
+  field: string;
+  label?: LocalizedText;
+  component?: string;
+  order?: number;
+  hidden?: boolean;
+  width?: number;
+  span?: number;
+  placeholder?: LocalizedText;
+  help?: LocalizedText;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageActionPresentation {
+  action: string;
+  label?: LocalizedText;
+  placement: PresentationActionPlacement;
+  order: number;
+  hidden: boolean;
+  confirm?: LocalizedText;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageActionPresentationPatch {
+  action: string;
+  label?: LocalizedText;
+  placement?: PresentationActionPlacement;
+  order?: number;
+  hidden?: boolean;
+  confirm?: LocalizedText;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageSort {
+  field: string;
+  direction: PresentationSortDirection;
+}
+
+export interface ResolvedPagePresentation {
+  title: LocalizedText;
+  dataSource: string;
+  list: {
+    columns: readonly PageFieldPresentation[];
+    density: PresentationDensity;
+    pageSize: number;
+    defaultSort: readonly PageSort[];
+  };
+  search: {
+    fields: readonly PageFieldPresentation[];
+    collapsedByDefault: boolean;
+  };
+  form: {
+    fields: readonly PageFieldPresentation[];
+    columns: number;
+  };
+  detail: {
+    fields: readonly PageFieldPresentation[];
+    columns: number;
+  };
+  actions: readonly PageActionPresentation[];
+}
+
+export interface PageCapabilityDefinition {
+  pageKey: string;
+  definitionVersion: string;
+  definitionHash: string;
+  components: readonly PageCapabilityComponent[];
+  fields: readonly PageCapabilityField[];
+  dataSources: readonly PageCapabilityDataSource[];
+  actions: readonly PageCapabilityAction[];
+  defaultPresentation: ResolvedPagePresentation;
+}
+
+export interface PagePresentationSpec {
+  title?: LocalizedText;
+  dataSource?: string;
+  list?: {
+    columns?: readonly PageFieldPresentationPatch[];
+    density?: PresentationDensity;
+    pageSize?: number;
+    defaultSort?: readonly PageSort[];
+  };
+  search?: {
+    fields?: readonly PageFieldPresentationPatch[];
+    collapsedByDefault?: boolean;
+  };
+  form?: {
+    fields?: readonly PageFieldPresentationPatch[];
+    columns?: number;
+  };
+  detail?: {
+    fields?: readonly PageFieldPresentationPatch[];
+    columns?: number;
+  };
+  actions?: readonly PageActionPresentationPatch[];
+}
+
+export type PagePresentationScope =
+  | { kind: 'application' }
+  | { kind: 'role'; subject: string }
+  | { kind: 'user'; subject: string };
+
+export interface AdminPagePresentationProfile {
+  apiVersion: typeof ADMIN_PRESENTATION_API_VERSION;
+  kind: typeof ADMIN_PRESENTATION_KIND;
+  metadata: {
+    name: string;
+    pageKey: string;
+    description?: string;
+    definitionHash: string;
+    scope: PagePresentationScope;
+  };
+  spec: PagePresentationSpec;
+}
+
+export interface PresentationLayers {
+  application?: AdminPagePresentationProfile;
+  role?: AdminPagePresentationProfile;
+  user?: AdminPagePresentationProfile;
+}
+
+export interface PresentationIssue {
+  code: string;
+  path: string;
+  message: string;
+}
+
+export interface RejectedPresentationLayer {
+  layer: PresentationLayer;
+  profileName: string;
+  issues: readonly PresentationIssue[];
+}
+
+export interface PresentationResolution {
+  presentation: ResolvedPagePresentation;
+  authorized: boolean;
+  appliedLayers: readonly PresentationLayer[];
+  rejectedLayers: readonly RejectedPresentationLayer[];
+  removedActionIds: readonly string[];
+}
+
+export interface PageRenderField {
+  field: string;
+  label: string;
+  component: string;
+  order: number;
+  width?: number;
+  span?: number;
+  placeholder?: string;
+  help?: string;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageRenderAction {
+  action: string;
+  label: string;
+  placement: PresentationActionPlacement;
+  order: number;
+  confirm?: string;
+  visibleWhen?: PresentationCondition;
+}
+
+export interface PageRenderModel {
+  pageKey: string;
+  status: 'ready' | 'permission-denied';
+  title: string;
+  dataSource?: string;
+  list: {
+    columns: readonly PageRenderField[];
+    density: PresentationDensity;
+    pageSize: number;
+    defaultSort: readonly PageSort[];
+  };
+  search: {
+    fields: readonly PageRenderField[];
+    collapsedByDefault: boolean;
+  };
+  form: {
+    fields: readonly PageRenderField[];
+    columns: number;
+  };
+  detail: {
+    fields: readonly PageRenderField[];
+    columns: number;
+  };
+  actions: readonly PageRenderAction[];
+}
+
+const layerOrder: readonly PresentationLayer[] = ['application', 'role', 'user'];
+const identifierPattern = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const definitionHashPattern = /^sha256:[0-9a-f]{64}$/;
+const predicateOperators = new Set<PresentationPredicateOperator>([
+  'eq',
+  'neq',
+  'in',
+  'not-in',
+  'exists',
+  'not-exists',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+]);
+const forbiddenProfileKeys = new Set([
+  'permission',
+  'permissions',
+  'route',
+  'url',
+  'method',
+  'headers',
+  'html',
+  'script',
+  'expression',
+  'sql',
+  'import',
+  'componentImport',
+  'plugin',
+  'template',
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export function canonicalizeCapabilityContract(value: unknown): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Capability contract numbers must be finite');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizeCapabilityContract).join(',')}]`;
+  }
+  if (isRecord(value)) {
+    const properties = Object.entries(value)
+      .filter(([, nested]) => nested !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => `${JSON.stringify(key)}:${canonicalizeCapabilityContract(nested)}`);
+    return `{${properties.join(',')}}`;
+  }
+  throw new Error(`Unsupported capability contract value: ${typeof value}`);
+}
+
+function addIssue(issues: PresentationIssue[], code: string, path: string, message: string) {
+  issues.push({ code, path, message });
+}
+
+function duplicateIDs(values: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+function cloneLocalized(value: LocalizedText | undefined): LocalizedText | undefined {
+  return value ? { ...value } : undefined;
+}
+
+function mergeLocalized(
+  current: LocalizedText | undefined,
+  patch: LocalizedText | undefined,
+): LocalizedText | undefined {
+  if (!patch) return cloneLocalized(current);
+  return { ...current, ...patch };
+}
+
+function cloneCondition(
+  condition: PresentationCondition | undefined,
+): PresentationCondition | undefined {
+  if (!condition) return undefined;
+  if ('all' in condition) {
+    return { all: condition.all.map((item) => cloneCondition(item) as PresentationCondition) };
+  }
+  if ('any' in condition) {
+    return { any: condition.any.map((item) => cloneCondition(item) as PresentationCondition) };
+  }
+  if ('not' in condition) {
+    return { not: cloneCondition(condition.not) as PresentationCondition };
+  }
+  return {
+    field: condition.field,
+    operator: condition.operator,
+    value: Array.isArray(condition.value) ? [...condition.value] : condition.value,
+  };
+}
+
+function cloneField(field: PageFieldPresentation): PageFieldPresentation {
+  return {
+    ...field,
+    label: cloneLocalized(field.label),
+    placeholder: cloneLocalized(field.placeholder),
+    help: cloneLocalized(field.help),
+    visibleWhen: cloneCondition(field.visibleWhen),
+  };
+}
+
+function cloneAction(action: PageActionPresentation): PageActionPresentation {
+  return {
+    ...action,
+    label: cloneLocalized(action.label),
+    confirm: cloneLocalized(action.confirm),
+    visibleWhen: cloneCondition(action.visibleWhen),
+  };
+}
+
+function clonePresentation(value: ResolvedPagePresentation): ResolvedPagePresentation {
+  return {
+    title: { ...value.title },
+    dataSource: value.dataSource,
+    list: {
+      ...value.list,
+      columns: value.list.columns.map(cloneField),
+      defaultSort: value.list.defaultSort.map((sort) => ({ ...sort })),
+    },
+    search: { ...value.search, fields: value.search.fields.map(cloneField) },
+    form: { ...value.form, fields: value.form.fields.map(cloneField) },
+    detail: { ...value.detail, fields: value.detail.fields.map(cloneField) },
+    actions: value.actions.map(cloneAction),
+  };
+}
+
+function validateLocalizedText(
+  value: LocalizedText | undefined,
+  path: string,
+  issues: PresentationIssue[],
+) {
+  if (!value) return;
+  if (!value['zh-CN'] && !value['en-US']) {
+    addIssue(issues, 'empty-localized-text', path, 'Localized text must contain zh-CN or en-US');
+  }
+}
+
+function validateCondition(
+  condition: PresentationCondition | undefined,
+  fields: ReadonlySet<string>,
+  path: string,
+  issues: PresentationIssue[],
+  depth = 0,
+) {
+  if (!condition) return;
+  if (depth > 8) {
+    addIssue(issues, 'condition-depth', path, 'Condition depth exceeds the limit of eight');
+    return;
+  }
+  if ('all' in condition) {
+    const children = condition.all;
+    if (children.length === 0 || children.length > 20) {
+      addIssue(issues, 'condition-size', `${path}.all`, 'Condition group must have 1 to 20 items');
+    }
+    children.forEach((child, index) => {
+      validateCondition(child, fields, `${path}.all[${index}]`, issues, depth + 1);
+    });
+    return;
+  }
+  if ('any' in condition) {
+    const children = condition.any;
+    if (children.length === 0 || children.length > 20) {
+      addIssue(issues, 'condition-size', `${path}.any`, 'Condition group must have 1 to 20 items');
+    }
+    children.forEach((child, index) => {
+      validateCondition(child, fields, `${path}.any[${index}]`, issues, depth + 1);
+    });
+    return;
+  }
+  if ('not' in condition) {
+    validateCondition(condition.not, fields, `${path}.not`, issues, depth + 1);
+    return;
+  }
+  if (!fields.has(condition.field)) {
+    addIssue(
+      issues,
+      'unknown-condition-field',
+      `${path}.field`,
+      `Unknown condition field ${condition.field}`,
+    );
+  }
+  if (!predicateOperators.has(condition.operator)) {
+    addIssue(
+      issues,
+      'unknown-condition-operator',
+      `${path}.operator`,
+      `Unknown condition operator ${condition.operator}`,
+    );
+  }
+  const presenceOperator = condition.operator === 'exists' || condition.operator === 'not-exists';
+  if (presenceOperator && condition.value !== undefined) {
+    addIssue(
+      issues,
+      'unexpected-condition-value',
+      `${path}.value`,
+      'Presence operators take no value',
+    );
+  }
+  if (!presenceOperator && condition.value === undefined) {
+    addIssue(
+      issues,
+      'missing-condition-value',
+      `${path}.value`,
+      'Comparison operator needs a value',
+    );
+  }
+  if (Array.isArray(condition.value) && condition.value.length > 50) {
+    addIssue(issues, 'condition-value-size', `${path}.value`, 'Condition value has over 50 items');
+  }
+}
+
+function inspectForbiddenKeys(value: unknown, path: string, issues: PresentationIssue[]) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      inspectForbiddenKeys(item, `${path}[${index}]`, issues);
+    });
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (forbiddenProfileKeys.has(key)) {
+      addIssue(
+        issues,
+        'forbidden-profile-key',
+        `${path}.${key}`,
+        `Presentation profiles cannot contain ${key}`,
+      );
+    }
+    inspectForbiddenKeys(nested, `${path}.${key}`, issues);
+  }
+}
+
+function validateFieldCollection(
+  capability: PageCapabilityDefinition,
+  surface: PresentationSurface,
+  fields: readonly PageFieldPresentationPatch[],
+  path: string,
+  issues: PresentationIssue[],
+) {
+  const fieldDefinitions = new Map(capability.fields.map((field) => [field.id, field]));
+  const componentIDs = new Set(capability.components.map((component) => component.id));
+  for (const duplicate of duplicateIDs(fields.map((field) => field.field))) {
+    addIssue(issues, 'duplicate-field', path, `Field ${duplicate} is configured more than once`);
+  }
+  fields.forEach((field, index) => {
+    const fieldPath = `${path}[${index}]`;
+    const definition = fieldDefinitions.get(field.field);
+    if (!definition) {
+      addIssue(issues, 'unknown-field', `${fieldPath}.field`, `Unknown field ${field.field}`);
+      return;
+    }
+    if (!definition.surfaces.includes(surface)) {
+      addIssue(
+        issues,
+        'unsupported-field-surface',
+        `${fieldPath}.field`,
+        `Field ${field.field} is not registered for ${surface}`,
+      );
+    }
+    if (field.component) {
+      if (!componentIDs.has(field.component)) {
+        addIssue(
+          issues,
+          'unknown-component',
+          `${fieldPath}.component`,
+          `Unknown component ${field.component}`,
+        );
+      } else if (!definition.components.includes(field.component)) {
+        addIssue(
+          issues,
+          'unsupported-field-component',
+          `${fieldPath}.component`,
+          `Component ${field.component} is not allowed for ${field.field}`,
+        );
+      }
+    }
+    if (surface === 'form' && definition.required && field.hidden === true) {
+      addIssue(
+        issues,
+        'required-form-field-hidden',
+        `${fieldPath}.hidden`,
+        `Required form field ${field.field} cannot be hidden`,
+      );
+    }
+    if (field.order !== undefined && (!Number.isInteger(field.order) || field.order < 0)) {
+      addIssue(
+        issues,
+        'invalid-field-order',
+        `${fieldPath}.order`,
+        'Field order must be non-negative',
+      );
+    }
+    if (field.width !== undefined && (field.width < 60 || field.width > 1200)) {
+      addIssue(
+        issues,
+        'invalid-field-width',
+        `${fieldPath}.width`,
+        'Field width must be 60 to 1200',
+      );
+    }
+    if (field.span !== undefined && (field.span < 1 || field.span > 24)) {
+      addIssue(issues, 'invalid-field-span', `${fieldPath}.span`, 'Field span must be 1 to 24');
+    }
+    validateLocalizedText(field.label, `${fieldPath}.label`, issues);
+    validateLocalizedText(field.placeholder, `${fieldPath}.placeholder`, issues);
+    validateLocalizedText(field.help, `${fieldPath}.help`, issues);
+    validateCondition(
+      field.visibleWhen,
+      new Set(fieldDefinitions.keys()),
+      `${fieldPath}.visibleWhen`,
+      issues,
+    );
+  });
+}
+
+function surfaceFields(
+  presentation: ResolvedPagePresentation,
+  surface: PresentationSurface,
+): readonly PageFieldPresentation[] {
+  if (surface === 'list') return presentation.list.columns;
+  return presentation[surface].fields;
+}
+
+function validateCompletePresentation(
+  capability: PageCapabilityDefinition,
+  presentation: ResolvedPagePresentation,
+): PresentationIssue[] {
+  const issues: PresentationIssue[] = [];
+  const dataSourceIDs = new Set(capability.dataSources.map((dataSource) => dataSource.id));
+  if (!dataSourceIDs.has(presentation.dataSource)) {
+    addIssue(
+      issues,
+      'unknown-data-source',
+      'defaultPresentation.dataSource',
+      `Unknown data source ${presentation.dataSource}`,
+    );
+  }
+  for (const surface of ['list', 'search', 'form', 'detail'] as const) {
+    validateFieldCollection(
+      capability,
+      surface,
+      surfaceFields(presentation, surface),
+      `defaultPresentation.${surface}`,
+      issues,
+    );
+  }
+  for (const field of capability.fields) {
+    for (const surface of field.surfaces) {
+      if (!surfaceFields(presentation, surface).some((item) => item.field === field.id)) {
+        addIssue(
+          issues,
+          'missing-default-field',
+          `defaultPresentation.${surface}`,
+          `Field ${field.id} needs a default entry for ${surface}`,
+        );
+      }
+    }
+  }
+  if (presentation.list.columns.every((field) => field.hidden)) {
+    addIssue(
+      issues,
+      'empty-list-presentation',
+      'defaultPresentation.list.columns',
+      'At least one list column must remain visible',
+    );
+  }
+  const fields = new Map(capability.fields.map((field) => [field.id, field]));
+  for (const [index, sort] of presentation.list.defaultSort.entries()) {
+    const definition = fields.get(sort.field);
+    if (!definition) {
+      addIssue(
+        issues,
+        'unknown-sort-field',
+        `defaultPresentation.list.defaultSort[${index}].field`,
+        `Unknown sort field ${sort.field}`,
+      );
+    } else if (!definition.sortable) {
+      addIssue(
+        issues,
+        'unsupported-sort-field',
+        `defaultPresentation.list.defaultSort[${index}].field`,
+        `Field ${sort.field} is not sortable`,
+      );
+    }
+  }
+  const actionDefinitions = new Map(capability.actions.map((action) => [action.id, action]));
+  for (const duplicate of duplicateIDs(presentation.actions.map((action) => action.action))) {
+    addIssue(
+      issues,
+      'duplicate-action',
+      'defaultPresentation.actions',
+      `Action ${duplicate} is configured more than once`,
+    );
+  }
+  presentation.actions.forEach((action, index) => {
+    const definition = actionDefinitions.get(action.action);
+    if (!definition) {
+      addIssue(
+        issues,
+        'unknown-action',
+        `defaultPresentation.actions[${index}].action`,
+        `Unknown action ${action.action}`,
+      );
+    } else if (!definition.placements.includes(action.placement)) {
+      addIssue(
+        issues,
+        'unsupported-action-placement',
+        `defaultPresentation.actions[${index}].placement`,
+        `Action ${action.action} cannot be placed at ${action.placement}`,
+      );
+    }
+  });
+  return issues;
+}
+
+export function validatePageCapabilityDefinition(
+  capability: PageCapabilityDefinition,
+): PresentationIssue[] {
+  const issues: PresentationIssue[] = [];
+  if (!identifierPattern.test(capability.pageKey)) {
+    addIssue(issues, 'invalid-page-key', 'pageKey', 'Page key must be a stable identifier');
+  }
+  if (!capability.definitionVersion.trim()) {
+    addIssue(
+      issues,
+      'missing-definition-version',
+      'definitionVersion',
+      'Definition version is required',
+    );
+  }
+  if (!definitionHashPattern.test(capability.definitionHash)) {
+    addIssue(
+      issues,
+      'invalid-definition-hash',
+      'definitionHash',
+      'Definition hash must be sha256 followed by 64 lowercase hexadecimal characters',
+    );
+  }
+  for (const [path, values] of [
+    ['components', capability.components.map((item) => item.id)],
+    ['fields', capability.fields.map((item) => item.id)],
+    ['dataSources', capability.dataSources.map((item) => item.id)],
+    ['actions', capability.actions.map((item) => item.id)],
+  ] as const) {
+    for (const duplicate of duplicateIDs(values)) {
+      addIssue(
+        issues,
+        'duplicate-capability-id',
+        path,
+        `${duplicate} is registered more than once`,
+      );
+    }
+  }
+  const componentIDs = new Set(capability.components.map((component) => component.id));
+  capability.fields.forEach((field, index) => {
+    if (field.surfaces.length === 0) {
+      addIssue(
+        issues,
+        'missing-field-surface',
+        `fields[${index}].surfaces`,
+        `Field ${field.id} needs at least one surface`,
+      );
+    }
+    if (field.components.length === 0) {
+      addIssue(
+        issues,
+        'missing-field-component',
+        `fields[${index}].components`,
+        `Field ${field.id} needs at least one component`,
+      );
+    }
+    for (const component of field.components) {
+      if (!componentIDs.has(component)) {
+        addIssue(
+          issues,
+          'unknown-field-component',
+          `fields[${index}].components`,
+          `Field ${field.id} references unknown component ${component}`,
+        );
+      }
+    }
+  });
+  capability.dataSources.forEach((dataSource, index) => {
+    if (
+      dataSource.requiredPermissions.length === 0 ||
+      dataSource.requiredPermissions.some((permission) => !permission.trim())
+    ) {
+      addIssue(
+        issues,
+        'missing-data-source-permission',
+        `dataSources[${index}].requiredPermissions`,
+        `Data source ${dataSource.id} needs non-empty permissions`,
+      );
+    }
+  });
+  capability.actions.forEach((action, index) => {
+    if (
+      action.requiredPermissions.length === 0 ||
+      action.requiredPermissions.some((permission) => !permission.trim())
+    ) {
+      addIssue(
+        issues,
+        'missing-action-permission',
+        `actions[${index}].requiredPermissions`,
+        `Action ${action.id} needs non-empty permissions`,
+      );
+    }
+  });
+  issues.push(...validateCompletePresentation(capability, capability.defaultPresentation));
+  return issues;
+}
+
+export function validatePagePresentationProfile(
+  capability: PageCapabilityDefinition,
+  profile: AdminPagePresentationProfile,
+): PresentationIssue[] {
+  const issues: PresentationIssue[] = [];
+  inspectForbiddenKeys(profile, '$', issues);
+  if (profile.apiVersion !== ADMIN_PRESENTATION_API_VERSION) {
+    addIssue(
+      issues,
+      'unsupported-api-version',
+      'apiVersion',
+      'Unsupported presentation API version',
+    );
+  }
+  if (profile.kind !== ADMIN_PRESENTATION_KIND) {
+    addIssue(issues, 'unsupported-kind', 'kind', 'Unsupported presentation document kind');
+  }
+  if (profile.metadata.pageKey !== capability.pageKey) {
+    addIssue(
+      issues,
+      'page-key-mismatch',
+      'metadata.pageKey',
+      `Expected page key ${capability.pageKey}`,
+    );
+  }
+  if (profile.metadata.definitionHash !== capability.definitionHash) {
+    addIssue(
+      issues,
+      'definition-hash-mismatch',
+      'metadata.definitionHash',
+      'Presentation profile was created for another capability definition',
+    );
+  }
+  if (profile.metadata.scope.kind !== 'application' && !profile.metadata.scope.subject.trim()) {
+    addIssue(
+      issues,
+      'missing-scope-subject',
+      'metadata.scope.subject',
+      'Scope subject is required',
+    );
+  }
+  const dataSourceIDs = new Set(capability.dataSources.map((dataSource) => dataSource.id));
+  if (profile.spec.dataSource && !dataSourceIDs.has(profile.spec.dataSource)) {
+    addIssue(
+      issues,
+      'unknown-data-source',
+      'spec.dataSource',
+      `Unknown data source ${profile.spec.dataSource}`,
+    );
+  }
+  validateLocalizedText(profile.spec.title, 'spec.title', issues);
+  if (profile.spec.list?.columns) {
+    validateFieldCollection(
+      capability,
+      'list',
+      profile.spec.list.columns,
+      'spec.list.columns',
+      issues,
+    );
+  }
+  if (profile.spec.search?.fields) {
+    validateFieldCollection(
+      capability,
+      'search',
+      profile.spec.search.fields,
+      'spec.search.fields',
+      issues,
+    );
+  }
+  if (profile.spec.form?.fields) {
+    validateFieldCollection(
+      capability,
+      'form',
+      profile.spec.form.fields,
+      'spec.form.fields',
+      issues,
+    );
+  }
+  if (profile.spec.detail?.fields) {
+    validateFieldCollection(
+      capability,
+      'detail',
+      profile.spec.detail.fields,
+      'spec.detail.fields',
+      issues,
+    );
+  }
+  const fieldDefinitions = new Map(capability.fields.map((field) => [field.id, field]));
+  profile.spec.list?.defaultSort?.forEach((sort, index) => {
+    const definition = fieldDefinitions.get(sort.field);
+    if (!definition) {
+      addIssue(
+        issues,
+        'unknown-sort-field',
+        `spec.list.defaultSort[${index}].field`,
+        `Unknown sort field ${sort.field}`,
+      );
+    } else if (!definition.sortable) {
+      addIssue(
+        issues,
+        'unsupported-sort-field',
+        `spec.list.defaultSort[${index}].field`,
+        `Field ${sort.field} is not sortable`,
+      );
+    }
+  });
+  const actions = new Map(capability.actions.map((action) => [action.id, action]));
+  for (const duplicate of duplicateIDs(
+    (profile.spec.actions ?? []).map((action) => action.action),
+  )) {
+    addIssue(issues, 'duplicate-action', 'spec.actions', `Action ${duplicate} is configured twice`);
+  }
+  profile.spec.actions?.forEach((action, index) => {
+    const definition = actions.get(action.action);
+    if (!definition) {
+      addIssue(
+        issues,
+        'unknown-action',
+        `spec.actions[${index}].action`,
+        `Unknown action ${action.action}`,
+      );
+      return;
+    }
+    if (action.placement && !definition.placements.includes(action.placement)) {
+      addIssue(
+        issues,
+        'unsupported-action-placement',
+        `spec.actions[${index}].placement`,
+        `Action ${action.action} cannot be placed at ${action.placement}`,
+      );
+    }
+    validateLocalizedText(action.label, `spec.actions[${index}].label`, issues);
+    validateLocalizedText(action.confirm, `spec.actions[${index}].confirm`, issues);
+    validateCondition(
+      action.visibleWhen,
+      new Set(fieldDefinitions.keys()),
+      `spec.actions[${index}].visibleWhen`,
+      issues,
+    );
+  });
+  return issues;
+}
+
+function mergeFieldCollection(
+  current: readonly PageFieldPresentation[],
+  patches: readonly PageFieldPresentationPatch[] | undefined,
+): readonly PageFieldPresentation[] {
+  if (!patches) return current.map(cloneField);
+  const byField = new Map(current.map((field) => [field.field, cloneField(field)]));
+  for (const patch of patches) {
+    const existing = byField.get(patch.field);
+    if (!existing) continue;
+    byField.set(patch.field, {
+      ...existing,
+      label: mergeLocalized(existing.label, patch.label),
+      component: patch.component ?? existing.component,
+      order: patch.order ?? existing.order,
+      hidden: patch.hidden ?? existing.hidden,
+      width: patch.width ?? existing.width,
+      span: patch.span ?? existing.span,
+      placeholder: mergeLocalized(existing.placeholder, patch.placeholder),
+      help: mergeLocalized(existing.help, patch.help),
+      visibleWhen: patch.visibleWhen
+        ? cloneCondition(patch.visibleWhen)
+        : cloneCondition(existing.visibleWhen),
+    });
+  }
+  return [...byField.values()];
+}
+
+function mergeActions(
+  current: readonly PageActionPresentation[],
+  patches: readonly PageActionPresentationPatch[] | undefined,
+): readonly PageActionPresentation[] {
+  if (!patches) return current.map(cloneAction);
+  const byAction = new Map(current.map((action) => [action.action, cloneAction(action)]));
+  for (const patch of patches) {
+    const existing = byAction.get(patch.action);
+    if (!existing) continue;
+    byAction.set(patch.action, {
+      ...existing,
+      label: mergeLocalized(existing.label, patch.label),
+      placement: patch.placement ?? existing.placement,
+      order: patch.order ?? existing.order,
+      hidden: patch.hidden ?? existing.hidden,
+      confirm: mergeLocalized(existing.confirm, patch.confirm),
+      visibleWhen: patch.visibleWhen
+        ? cloneCondition(patch.visibleWhen)
+        : cloneCondition(existing.visibleWhen),
+    });
+  }
+  return [...byAction.values()];
+}
+
+function applyProfile(
+  current: ResolvedPagePresentation,
+  profile: AdminPagePresentationProfile,
+): ResolvedPagePresentation {
+  const spec = profile.spec;
+  return {
+    title: mergeLocalized(current.title, spec.title) ?? {},
+    dataSource: spec.dataSource ?? current.dataSource,
+    list: {
+      columns: mergeFieldCollection(current.list.columns, spec.list?.columns),
+      density: spec.list?.density ?? current.list.density,
+      pageSize: spec.list?.pageSize ?? current.list.pageSize,
+      defaultSort: spec.list?.defaultSort
+        ? spec.list.defaultSort.map((sort) => ({ ...sort }))
+        : current.list.defaultSort.map((sort) => ({ ...sort })),
+    },
+    search: {
+      fields: mergeFieldCollection(current.search.fields, spec.search?.fields),
+      collapsedByDefault: spec.search?.collapsedByDefault ?? current.search.collapsedByDefault,
+    },
+    form: {
+      fields: mergeFieldCollection(current.form.fields, spec.form?.fields),
+      columns: spec.form?.columns ?? current.form.columns,
+    },
+    detail: {
+      fields: mergeFieldCollection(current.detail.fields, spec.detail?.fields),
+      columns: spec.detail?.columns ?? current.detail.columns,
+    },
+    actions: mergeActions(current.actions, spec.actions),
+  };
+}
+
+export function resolvePagePresentation(
+  capability: PageCapabilityDefinition,
+  layers: PresentationLayers,
+  grantedPermissions: ReadonlySet<string>,
+): PresentationResolution {
+  const capabilityIssues = validatePageCapabilityDefinition(capability);
+  if (capabilityIssues.length > 0) {
+    throw new Error(
+      `Invalid page capability ${capability.pageKey}: ${capabilityIssues
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+  }
+
+  let presentation = clonePresentation(capability.defaultPresentation);
+  const appliedLayers: PresentationLayer[] = [];
+  const rejectedLayers: RejectedPresentationLayer[] = [];
+
+  for (const layer of layerOrder) {
+    const profile = layers[layer];
+    if (!profile) continue;
+    const issues = validatePagePresentationProfile(capability, profile);
+    if (profile.metadata.scope.kind !== layer) {
+      addIssue(
+        issues,
+        'scope-layer-mismatch',
+        'metadata.scope.kind',
+        `A ${layer} slot cannot contain a ${profile.metadata.scope.kind} profile`,
+      );
+    }
+    if (issues.length > 0) {
+      rejectedLayers.push({ layer, profileName: profile.metadata.name, issues });
+      continue;
+    }
+    const candidate = applyProfile(presentation, profile);
+    const candidateIssues = validateCompletePresentation(capability, candidate);
+    if (candidateIssues.length > 0) {
+      rejectedLayers.push({
+        layer,
+        profileName: profile.metadata.name,
+        issues: candidateIssues,
+      });
+      continue;
+    }
+    presentation = candidate;
+    appliedLayers.push(layer);
+  }
+
+  const dataSource = capability.dataSources.find(
+    (candidate) => candidate.id === presentation.dataSource,
+  );
+  const authorized = Boolean(
+    dataSource?.requiredPermissions.every((permission) => grantedPermissions.has(permission)),
+  );
+  const actionDefinitions = new Map(capability.actions.map((action) => [action.id, action]));
+  const removedActionIds: string[] = [];
+  const securedActions = presentation.actions.map((action) => {
+    const definition = actionDefinitions.get(action.action);
+    const permitted = Boolean(
+      authorized &&
+        definition?.requiredPermissions.every((permission) => grantedPermissions.has(permission)),
+    );
+    if (!permitted && !action.hidden) removedActionIds.push(action.action);
+    return { ...cloneAction(action), hidden: action.hidden || !permitted };
+  });
+
+  return {
+    presentation: { ...presentation, actions: securedActions },
+    authorized,
+    appliedLayers,
+    rejectedLayers,
+    removedActionIds: removedActionIds.sort(),
+  };
+}
+
+function localize(value: LocalizedText | undefined, locale: AdminLocale, fallback: string): string {
+  if (!value) return fallback;
+  const otherLocale: AdminLocale = locale === 'zh-CN' ? 'en-US' : 'zh-CN';
+  return value[locale]?.trim() || value[otherLocale]?.trim() || fallback;
+}
+
+function renderFields(
+  fields: readonly PageFieldPresentation[],
+  definitions: ReadonlyMap<string, PageCapabilityField>,
+  locale: AdminLocale,
+): readonly PageRenderField[] {
+  return fields
+    .filter((field) => !field.hidden)
+    .sort((left, right) => left.order - right.order || left.field.localeCompare(right.field))
+    .map((field) => {
+      const definition = definitions.get(field.field);
+      return {
+        field: field.field,
+        label: localize(field.label, locale, localize(definition?.label, locale, field.field)),
+        component: field.component,
+        order: field.order,
+        width: field.width,
+        span: field.span,
+        placeholder: field.placeholder
+          ? localize(field.placeholder, locale, field.field)
+          : undefined,
+        help: field.help ? localize(field.help, locale, field.field) : undefined,
+        visibleWhen: cloneCondition(field.visibleWhen),
+      };
+    });
+}
+
+export function buildPageRenderModel(
+  capability: PageCapabilityDefinition,
+  resolution: PresentationResolution,
+  locale: AdminLocale,
+): PageRenderModel {
+  const presentation = resolution.presentation;
+  const fields = new Map(capability.fields.map((field) => [field.id, field]));
+  const actions = presentation.actions
+    .filter((action) => !action.hidden)
+    .sort((left, right) => left.order - right.order || left.action.localeCompare(right.action))
+    .map((action) => ({
+      action: action.action,
+      label: localize(action.label, locale, action.action),
+      placement: action.placement,
+      order: action.order,
+      confirm: action.confirm ? localize(action.confirm, locale, action.action) : undefined,
+      visibleWhen: cloneCondition(action.visibleWhen),
+    }));
+
+  return {
+    pageKey: capability.pageKey,
+    status: resolution.authorized ? 'ready' : 'permission-denied',
+    title: localize(presentation.title, locale, capability.pageKey),
+    dataSource: resolution.authorized ? presentation.dataSource : undefined,
+    list: {
+      columns: renderFields(presentation.list.columns, fields, locale),
+      density: presentation.list.density,
+      pageSize: presentation.list.pageSize,
+      defaultSort: presentation.list.defaultSort.map((sort) => ({ ...sort })),
+    },
+    search: {
+      fields: renderFields(presentation.search.fields, fields, locale),
+      collapsedByDefault: presentation.search.collapsedByDefault,
+    },
+    form: {
+      fields: renderFields(presentation.form.fields, fields, locale),
+      columns: presentation.form.columns,
+    },
+    detail: {
+      fields: renderFields(presentation.detail.fields, fields, locale),
+      columns: presentation.detail.columns,
+    },
+    actions,
+  };
+}

--- a/web/antd-v6/src/shared/presentation/supplier.prototype.test.ts
+++ b/web/antd-v6/src/shared/presentation/supplier.prototype.test.ts
@@ -1,0 +1,86 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { supplierPermissionPaths } from '../../generated/modules/supplier/contract';
+import { canonicalizeCapabilityContract } from './contract';
+import {
+  buildSupplierCompactPrototype,
+  supplierPresentationCapability,
+  supplierPresentationCompatibility,
+} from './supplier.prototype';
+
+const allPermissions = new Set([
+  '/suppliers',
+  '/suppliers/permissions/list',
+  '/suppliers/permissions/read',
+  '/suppliers/permissions/create',
+  '/suppliers/permissions/update',
+  '/suppliers/permissions/delete',
+  '/suppliers/permissions/export',
+]);
+
+describe('Supplier presentation P0 prototype', () => {
+  it('uses the exact generated route and operation permission identifiers', () => {
+    expect(supplierPresentationCompatibility.dataSources[0]?.requiredPermissions).toEqual([
+      supplierPermissionPaths.route,
+      supplierPermissionPaths.list,
+    ]);
+    expect(
+      Object.fromEntries(
+        supplierPresentationCompatibility.actions.map((action) => [
+          action.id,
+          action.requiredPermissions,
+        ]),
+      ),
+    ).toEqual({
+      'supplier.create': [supplierPermissionPaths.route, supplierPermissionPaths.create],
+      'supplier.read': [supplierPermissionPaths.route, supplierPermissionPaths.read],
+      'supplier.update': [supplierPermissionPaths.route, supplierPermissionPaths.update],
+      'supplier.delete': [supplierPermissionPaths.route, supplierPermissionPaths.delete],
+      'supplier.export': [supplierPermissionPaths.route, supplierPermissionPaths.export],
+    });
+  });
+
+  it('binds the profile to the canonical trusted compatibility hash', () => {
+    const digest = createHash('sha256')
+      .update(canonicalizeCapabilityContract(supplierPresentationCompatibility))
+      .digest('hex');
+
+    expect(supplierPresentationCapability.definitionHash).toBe(`sha256:${digest}`);
+  });
+
+  it('projects a compact localized render model using profile data only', () => {
+    const model = buildSupplierCompactPrototype(allPermissions, 'zh-CN');
+
+    expect(model).toMatchObject({
+      pageKey: 'supplier.list',
+      status: 'ready',
+      title: '供应商概览',
+      dataSource: 'supplier.list',
+      list: { density: 'compact', pageSize: 50 },
+      search: { collapsedByDefault: false },
+    });
+    expect(model.list.columns.map((field) => [field.field, field.label])).toEqual([
+      ['code', '供应商编码'],
+      ['name', '供应商名称'],
+      ['enabled', '状态'],
+      ['creditLevel', '信用等级'],
+    ]);
+    expect(model.actions.map((action) => action.action)).toEqual([
+      'supplier.create',
+      'supplier.read',
+      'supplier.update',
+    ]);
+  });
+
+  it('is not imported by the production route registries', () => {
+    const routeSources = [
+      '../routes/registry.ts',
+      '../../generated/routes.ts',
+      '../../../config/routes.generated.ts',
+    ].map((path) => readFileSync(fileURLToPath(new URL(path, import.meta.url)), 'utf8'));
+
+    expect(routeSources.join('\n')).not.toContain('supplier.prototype');
+  });
+});

--- a/web/antd-v6/src/shared/presentation/supplier.prototype.ts
+++ b/web/antd-v6/src/shared/presentation/supplier.prototype.ts
@@ -1,0 +1,286 @@
+import {
+  ADMIN_PRESENTATION_API_VERSION,
+  ADMIN_PRESENTATION_KIND,
+  type AdminLocale,
+  type AdminPagePresentationProfile,
+  buildPageRenderModel,
+  type PageCapabilityDefinition,
+  type PageRenderModel,
+  resolvePagePresentation,
+} from './contract';
+
+/**
+ * P0 reference only. This compatibility surface mirrors the existing Supplier
+ * AdminModule but is deliberately not imported by the production route tree.
+ * A production adoption must move this projection into the deterministic
+ * AdminModule generator instead of hand-maintaining another source of truth.
+ */
+export const supplierPresentationCompatibility = {
+  pageKey: 'supplier.list',
+  definitionVersion: '1',
+  components: [
+    { id: 'boolean' },
+    { id: 'email-input' },
+    { id: 'input' },
+    { id: 'select' },
+    { id: 'switch' },
+    { id: 'tag' },
+    { id: 'text' },
+  ],
+  fields: [
+    {
+      id: 'code',
+      label: { 'zh-CN': '供应商编码', 'en-US': 'Code' },
+      valueType: 'string',
+      required: true,
+      sortable: true,
+      filterable: false,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['text', 'input'],
+    },
+    {
+      id: 'name',
+      label: { 'zh-CN': '供应商名称', 'en-US': 'Name' },
+      valueType: 'string',
+      required: true,
+      sortable: true,
+      filterable: false,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['text', 'input'],
+    },
+    {
+      id: 'country',
+      label: { 'zh-CN': '国家或地区', 'en-US': 'Country or region' },
+      valueType: 'string',
+      required: false,
+      sortable: false,
+      filterable: true,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['text', 'input'],
+    },
+    {
+      id: 'contactName',
+      label: { 'zh-CN': '联系人', 'en-US': 'Contact' },
+      valueType: 'string',
+      required: true,
+      sortable: false,
+      filterable: false,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['text', 'input'],
+    },
+    {
+      id: 'contactEmail',
+      label: { 'zh-CN': '联系邮箱', 'en-US': 'Contact email' },
+      valueType: 'string',
+      required: false,
+      sortable: false,
+      filterable: false,
+      surfaces: ['list', 'form', 'detail'],
+      components: ['text', 'email-input'],
+    },
+    {
+      id: 'creditLevel',
+      label: { 'zh-CN': '信用等级', 'en-US': 'Credit level' },
+      valueType: 'enum',
+      required: true,
+      sortable: false,
+      filterable: true,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['tag', 'select'],
+    },
+    {
+      id: 'enabled',
+      label: { 'zh-CN': '启用状态', 'en-US': 'Enabled' },
+      valueType: 'boolean',
+      required: true,
+      sortable: false,
+      filterable: true,
+      surfaces: ['list', 'search', 'form', 'detail'],
+      components: ['boolean', 'switch'],
+    },
+  ],
+  dataSources: [
+    {
+      id: 'supplier.list',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/list'],
+    },
+  ],
+  actions: [
+    {
+      id: 'supplier.create',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/create'],
+      placements: ['toolbar'],
+    },
+    {
+      id: 'supplier.read',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/read'],
+      placements: ['row', 'detail'],
+    },
+    {
+      id: 'supplier.update',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/update'],
+      placements: ['row', 'form'],
+    },
+    {
+      id: 'supplier.delete',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/delete'],
+      placements: ['row'],
+      destructive: true,
+    },
+    {
+      id: 'supplier.export',
+      requiredPermissions: ['/suppliers', '/suppliers/permissions/export'],
+      placements: ['toolbar'],
+    },
+  ],
+} as const;
+
+export const supplierPresentationCapability: PageCapabilityDefinition = {
+  ...supplierPresentationCompatibility,
+  definitionHash: 'sha256:276e11ca561729c8b288c4bb045364dbc442ba56ccc5fb59ffdab19f7e5ee473',
+  defaultPresentation: {
+    title: { 'zh-CN': '供应商管理', 'en-US': 'Suppliers' },
+    dataSource: 'supplier.list',
+    list: {
+      density: 'middle',
+      pageSize: 20,
+      defaultSort: [{ field: 'code', direction: 'asc' }],
+      columns: [
+        { field: 'code', component: 'text', order: 10, hidden: false, width: 180 },
+        { field: 'name', component: 'text', order: 20, hidden: false, width: 240 },
+        { field: 'country', component: 'text', order: 30, hidden: false },
+        { field: 'contactName', component: 'text', order: 40, hidden: false },
+        { field: 'contactEmail', component: 'text', order: 50, hidden: false },
+        { field: 'creditLevel', component: 'tag', order: 60, hidden: false },
+        { field: 'enabled', component: 'boolean', order: 70, hidden: false },
+      ],
+    },
+    search: {
+      collapsedByDefault: true,
+      fields: [
+        { field: 'code', component: 'input', order: 10, hidden: false },
+        { field: 'name', component: 'input', order: 20, hidden: false },
+        { field: 'country', component: 'input', order: 30, hidden: false },
+        { field: 'contactName', component: 'input', order: 40, hidden: false },
+        { field: 'creditLevel', component: 'select', order: 50, hidden: false },
+        { field: 'enabled', component: 'switch', order: 60, hidden: false },
+      ],
+    },
+    form: {
+      columns: 2,
+      fields: [
+        { field: 'code', component: 'input', order: 10, hidden: false, span: 12 },
+        { field: 'name', component: 'input', order: 20, hidden: false, span: 12 },
+        { field: 'country', component: 'input', order: 30, hidden: false, span: 12 },
+        { field: 'contactName', component: 'input', order: 40, hidden: false, span: 12 },
+        {
+          field: 'contactEmail',
+          component: 'email-input',
+          order: 50,
+          hidden: false,
+          span: 12,
+        },
+        { field: 'creditLevel', component: 'select', order: 60, hidden: false, span: 12 },
+        { field: 'enabled', component: 'switch', order: 70, hidden: false, span: 12 },
+      ],
+    },
+    detail: {
+      columns: 2,
+      fields: [
+        { field: 'code', component: 'text', order: 10, hidden: false, span: 12 },
+        { field: 'name', component: 'text', order: 20, hidden: false, span: 12 },
+        { field: 'country', component: 'text', order: 30, hidden: false, span: 12 },
+        { field: 'contactName', component: 'text', order: 40, hidden: false, span: 12 },
+        { field: 'contactEmail', component: 'text', order: 50, hidden: false, span: 12 },
+        { field: 'creditLevel', component: 'tag', order: 60, hidden: false, span: 12 },
+        { field: 'enabled', component: 'boolean', order: 70, hidden: false, span: 12 },
+      ],
+    },
+    actions: [
+      {
+        action: 'supplier.create',
+        label: { 'zh-CN': '新建供应商', 'en-US': 'Create supplier' },
+        placement: 'toolbar',
+        order: 10,
+        hidden: false,
+      },
+      {
+        action: 'supplier.export',
+        label: { 'zh-CN': '导出', 'en-US': 'Export' },
+        placement: 'toolbar',
+        order: 20,
+        hidden: false,
+      },
+      {
+        action: 'supplier.read',
+        label: { 'zh-CN': '查看', 'en-US': 'View' },
+        placement: 'row',
+        order: 30,
+        hidden: false,
+      },
+      {
+        action: 'supplier.update',
+        label: { 'zh-CN': '编辑', 'en-US': 'Edit' },
+        placement: 'row',
+        order: 40,
+        hidden: false,
+      },
+      {
+        action: 'supplier.delete',
+        label: { 'zh-CN': '删除', 'en-US': 'Delete' },
+        placement: 'row',
+        order: 50,
+        hidden: false,
+        confirm: {
+          'zh-CN': '确认删除该供应商？',
+          'en-US': 'Delete this supplier?',
+        },
+      },
+    ],
+  },
+};
+
+export const supplierCompactApplicationProfile: AdminPagePresentationProfile = {
+  apiVersion: ADMIN_PRESENTATION_API_VERSION,
+  kind: ADMIN_PRESENTATION_KIND,
+  metadata: {
+    name: 'supplier-compact',
+    pageKey: supplierPresentationCapability.pageKey,
+    description: 'P0 compact Supplier list reference without persistence or route registration.',
+    definitionHash: supplierPresentationCapability.definitionHash,
+    scope: { kind: 'application' },
+  },
+  spec: {
+    title: { 'zh-CN': '供应商概览', 'en-US': 'Supplier overview' },
+    list: {
+      density: 'compact',
+      pageSize: 50,
+      columns: [
+        { field: 'country', hidden: true },
+        { field: 'contactName', hidden: true },
+        { field: 'contactEmail', hidden: true },
+        { field: 'enabled', order: 25, label: { 'zh-CN': '状态', 'en-US': 'Status' } },
+      ],
+    },
+    search: {
+      collapsedByDefault: false,
+      fields: [{ field: 'contactName', hidden: true }],
+    },
+    actions: [
+      { action: 'supplier.export', hidden: true },
+      { action: 'supplier.delete', hidden: true },
+    ],
+  },
+};
+
+export function buildSupplierCompactPrototype(
+  grantedPermissions: ReadonlySet<string>,
+  locale: AdminLocale = 'zh-CN',
+): PageRenderModel {
+  const resolution = resolvePagePresentation(
+    supplierPresentationCapability,
+    { application: supplierCompactApplicationProfile },
+    grantedPermissions,
+  );
+  return buildPageRenderModel(supplierPresentationCapability, resolution, locale);
+}


### PR DESCRIPTION
## Summary

- add a validated FeatureSpec, planned capability entry, strict JSON Schema, and ADR for governed Admin page presentation configuration
- add a data-only TypeScript capability/profile contract with deterministic `code < application < role < user` resolution, whole-layer drift rejection, and permission intersection applied last
- add a non-production Supplier reference profile tied to the exact generated route/operation permission identifiers and a canonical SHA-256 capability hash
- add Go schema safety tests and frontend contract tests for precedence, immutability, unknown references, required-field safety, drift fallback, route isolation, and authorization

## Boundary

P0 does **not** add a production route, API, database table, migration, draft/publish service, menu, browser storage, package export, or generated-file change. Profiles cannot carry permissions, routes, URLs, methods, headers, scripts, HTML, SQL, imports, templates, plugins, or component implementations. Runtime dynamic models, virtual CRUD, and browser code generation remain removed.

## Security impact

- permission requirements remain in trusted compiled capability definitions and are intersected after all editable presentation layers
- stale hashes, unknown references, incompatible components, hidden required fields, and executable or transport-shaped keys fail closed
- backend authorization remains authoritative; P0 adds no credential, secret, network request, or persisted untrusted document

## Compatibility and release impact

This is a source-only Planned capability and shadow prototype. It changes no existing route, generated contract, public package export, database schema, migration, runtime bundle, or release artifact. Rollback is a normal revert of this single commit.

## Validation

- `go run ./cmd/mss spec validate .mss/features/admin-presentation-configuration.yaml --format json`
- `go test ./internal/mss/spec`
- focused presentation Vitest: 2 files / 11 tests passed
- `corepack pnpm@10.34.5 --dir web/antd-v6 lint`
- `corepack pnpm@10.34.5 --dir web/antd-v6 build:release`
- `corepack pnpm@9.15.9 --dir docs build`
- `go run ./cmd/mss verify --changed` — success; contract validation, Agent tooling tests, docs build, frontend lint, all 72 frontend test files, and diff check passed
- no `go.sum`, `go.work.sum`, or lockfile changes

## Next phase

P1 must be a separate reviewed FeatureSpec for authoritative draft validation, ETag publish, immutable history, rollback, authorization, audit, drift diagnostics, caching, and an unconfigurable recovery mode. This P0 prototype must not be wired directly into production.
