### PR TITLE
fix(mss): pin exact frontend tarball in Thin Host locks

### DIFF
--- a/.github/workflows/foundation-compatibility.yml
+++ b/.github/workflows/foundation-compatibility.yml
@@ -120,26 +120,37 @@ jobs:
           version = sys.argv[2].removeprefix('v')
           if not re.fullmatch(r'(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)', version):
               raise SystemExit(f'invalid compatibility Admin Web version: {version}')
-          integrity = 'sha512-' + base64.b64encode(
-              sha512(f'foundation-compatibility-admin-web-{version}'.encode('utf-8')).digest()
-          ).decode('ascii')
+          tarball = f'foundation-compatibility-admin-web-{version}'.encode('utf-8')
+          integrity = 'sha512-' + base64.b64encode(sha512(tarball).digest()).decode('ascii')
+          metadata_path = f'/{package_name}/{version}'
+          tarball_path = f'/artifacts/foundation-compatibility-admin-web-{version}.tgz'
 
           class Handler(BaseHTTPRequestHandler):
               def do_GET(self):
                   path = unquote(urlsplit(self.path).path)
-                  if path != f'/{package_name}/{version}':
-                      self.send_error(404)
+                  if path == metadata_path:
+                      payload = json.dumps({
+                          'name': package_name,
+                          'version': version,
+                          'dist': {
+                              'integrity': integrity,
+                              'tarball': f'http://127.0.0.1:{self.server.server_port}{tarball_path}',
+                          },
+                      }, separators=(',', ':')).encode('utf-8')
+                      self.send_response(200)
+                      self.send_header('Content-Type', 'application/json')
+                      self.send_header('Content-Length', str(len(payload)))
+                      self.end_headers()
+                      self.wfile.write(payload)
                       return
-                  payload = json.dumps({
-                      'name': package_name,
-                      'version': version,
-                      'dist': {'integrity': integrity},
-                  }, separators=(',', ':')).encode('utf-8')
-                  self.send_response(200)
-                  self.send_header('Content-Type', 'application/json')
-                  self.send_header('Content-Length', str(len(payload)))
-                  self.end_headers()
-                  self.wfile.write(payload)
+                  if path == tarball_path:
+                      self.send_response(200)
+                      self.send_header('Content-Type', 'application/octet-stream')
+                      self.send_header('Content-Length', str(len(tarball)))
+                      self.end_headers()
+                      self.wfile.write(tarball)
+                      return
+                  self.send_error(404)
 
               def log_message(self, _format, *_args):
                   return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ tag namespaces.
 
 ## [Unreleased]
 
-No unreleased changes are recorded.
+### Fixed
+
+- Preserve the exact Admin Web package tarball URL in generated Thin Host
+  lockfiles, and keep the downstream compatibility registry fixture aligned
+  with that metadata contract so frozen installs never infer a registry path.
 
 ## [v1.3.4] - 2026-08-25
 

--- a/internal/mss/app/new_test.go
+++ b/internal/mss/app/new_test.go
@@ -93,9 +93,14 @@ func TestGenerateApplicationDefaultsToEmbeddedSourceFromFoundationSubdirectory(t
 func appFrontendRegistry(t *testing.T) string {
 	t.Helper()
 	integrity := "sha512-" + strings.Repeat("A", 86) + "=="
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(writer, `{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q}}`, integrity)
+		_, _ = fmt.Fprintf(
+			writer,
+			`{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q,"tarball":%q}}`,
+			integrity,
+			"http://"+request.Host+"/artifacts/app-admin-web-1.3.4.tgz",
+		)
 	}))
 	t.Cleanup(server.Close)
 	return server.URL

--- a/internal/mss/blueprint/embedded_source.go
+++ b/internal/mss/blueprint/embedded_source.go
@@ -37,7 +37,7 @@ func GenerateEmbedded(ctx context.Context, workingDirectory string, options Opti
 	if err != nil {
 		return Plan{}, err
 	}
-	frontendIntegrity, err := resolveFrontendIntegrityForSource(ctx, options.FrontendRegistryURL, source.Blueprint, source.Files)
+	frontendPackage, err := resolveFrontendPackageForSource(ctx, options.FrontendRegistryURL, source.Blueprint, source.Files)
 	if err != nil {
 		return Plan{}, err
 	}
@@ -51,7 +51,7 @@ func GenerateEmbedded(ctx context.Context, workingDirectory string, options Opti
 		source.Identity,
 		source.Files,
 		options.Application,
-		frontendIntegrity,
+		frontendPackage,
 	)
 	if err != nil {
 		return Plan{}, err

--- a/internal/mss/blueprint/embedded_source_test.go
+++ b/internal/mss/blueprint/embedded_source_test.go
@@ -141,8 +141,14 @@ func TestGenerateEmbeddedWorksOutsideGitAndIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(lockData), frontendIntegrityToken) || !strings.Contains(string(lockData), "resolution: {integrity: sha512-") {
-		t.Fatalf("generated frontend lock did not resolve exact tarball integrity")
+	for _, forbidden := range []string{frontendIntegrityToken, frontendTarballToken, "NODE_AUTH_TOKEN", "_authToken"} {
+		if strings.Contains(string(lockData), forbidden) {
+			t.Fatalf("generated frontend lock contains forbidden value %q", forbidden)
+		}
+	}
+	if !strings.Contains(string(lockData), "resolution: {tarball: http://127.0.0.1:") ||
+		!strings.Contains(string(lockData), "/artifacts/frozen-admin-web-1.3.4.tgz, integrity: sha512-") {
+		t.Fatalf("generated frontend lock did not resolve the exact tarball URL and integrity")
 	}
 	goModuleData, err := os.ReadFile(filepath.Join(destination, "go.mod"))
 	if err != nil {
@@ -281,9 +287,14 @@ func setEmbeddedReleaseBuild(t *testing.T) {
 func embeddedFrontendRegistry(t *testing.T) string {
 	t.Helper()
 	integrity := testFrontendIntegrity("embedded-admin-web-candidate")
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(writer, `{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q}}`, integrity)
+		_, _ = fmt.Fprintf(
+			writer,
+			`{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q,"tarball":%q}}`,
+			integrity,
+			"http://"+request.Host+"/artifacts/frozen-admin-web-1.3.4.tgz",
+		)
 	}))
 	t.Cleanup(server.Close)
 	return server.URL

--- a/internal/mss/blueprint/frontend_integrity.go
+++ b/internal/mss/blueprint/frontend_integrity.go
@@ -17,51 +17,60 @@ import (
 const (
 	defaultFrontendRegistryURL = "https://registry.npmjs.org"
 	frontendIntegrityToken     = "__MSS_DISTRIBUTION_FRONTEND_INTEGRITY__"
+	frontendTarballToken       = "__MSS_DISTRIBUTION_FRONTEND_TARBALL__"
 	maxFrontendMetadataBytes   = 1 << 20
 )
 
-// resolveFrontendIntegrityForSource resolves the immutable npm tarball SRI
-// only when a selected application template actually consumes it. Exact npm
-// versions are immutable, so the resolved value becomes part of the generated
+type frontendPackageResolution struct {
+	Integrity string
+	Tarball   string
+}
+
+// resolveFrontendPackageForSource resolves the immutable npm tarball URL and
+// SRI only when a selected application template actually consumes them. Exact
+// npm versions are immutable, so both values become part of the generated
 // snapshot and subsequent three-way upgrade baseline.
-func resolveFrontendIntegrityForSource(
+func resolveFrontendPackageForSource(
 	ctx context.Context,
 	registryURL string,
 	blueprint *Document,
 	sourceFiles []blueprintSourceFile,
-) (string, error) {
+) (frontendPackageResolution, error) {
 	needsIntegrity := false
+	needsTarball := false
 	for _, sourceFile := range sourceFiles {
-		if strings.Contains(string(sourceFile.Data), frontendIntegrityToken) {
-			needsIntegrity = true
-			break
-		}
+		text := string(sourceFile.Data)
+		needsIntegrity = needsIntegrity || strings.Contains(text, frontendIntegrityToken)
+		needsTarball = needsTarball || strings.Contains(text, frontendTarballToken)
 	}
-	if !needsIntegrity {
-		return "", nil
+	if !needsIntegrity && !needsTarball {
+		return frontendPackageResolution{}, nil
+	}
+	if !needsIntegrity || !needsTarball {
+		return frontendPackageResolution{}, errors.New("application template must consume frontend tarball and integrity together")
 	}
 	if blueprint == nil {
-		return "", errors.New("application blueprint is required to resolve frontend integrity")
+		return frontendPackageResolution{}, errors.New("application blueprint is required to resolve frontend package")
 	}
 	frontend := blueprint.Spec.Distribution.Frontend
-	integrity, err := resolveFrontendIntegrity(ctx, registryURL, frontend.Package, frontend.Version)
+	resolved, err := resolveFrontendPackage(ctx, registryURL, frontend.Package, frontend.Version)
 	if err != nil {
-		return "", fmt.Errorf("resolve frozen frontend %s@%s: %w", frontend.Package, frontend.Version, err)
+		return frontendPackageResolution{}, fmt.Errorf("resolve frozen frontend %s@%s: %w", frontend.Package, frontend.Version, err)
 	}
-	return integrity, nil
+	return resolved, nil
 }
 
-func resolveFrontendIntegrity(ctx context.Context, registryURL, packageName, version string) (string, error) {
+func resolveFrontendPackage(ctx context.Context, registryURL, packageName, version string) (frontendPackageResolution, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	endpoint, err := frontendMetadataEndpoint(registryURL, packageName, version)
 	if err != nil {
-		return "", err
+		return frontendPackageResolution{}, err
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return "", fmt.Errorf("create npm metadata request: %w", err)
+		return frontendPackageResolution{}, fmt.Errorf("create npm metadata request: %w", err)
 	}
 	request.Header.Set("Accept", "application/vnd.npm.install-v1+json, application/json")
 	client := &http.Client{
@@ -72,32 +81,33 @@ func resolveFrontendIntegrity(ctx context.Context, registryURL, packageName, ver
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return "", fmt.Errorf("fetch exact npm metadata: %w", err)
+		return frontendPackageResolution{}, fmt.Errorf("fetch exact npm metadata: %w", err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
-		return "", fmt.Errorf("npm registry returned HTTP %d", response.StatusCode)
+		return frontendPackageResolution{}, fmt.Errorf("npm registry returned HTTP %d", response.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(response.Body, maxFrontendMetadataBytes+1))
 	if err != nil {
-		return "", fmt.Errorf("read npm metadata: %w", err)
+		return frontendPackageResolution{}, fmt.Errorf("read npm metadata: %w", err)
 	}
 	if len(data) > maxFrontendMetadataBytes {
-		return "", fmt.Errorf("npm metadata exceeds %d bytes", maxFrontendMetadataBytes)
+		return frontendPackageResolution{}, fmt.Errorf("npm metadata exceeds %d bytes", maxFrontendMetadataBytes)
 	}
 	var metadata struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
 		Dist    struct {
 			Integrity string `json:"integrity"`
+			Tarball   string `json:"tarball"`
 		} `json:"dist"`
 	}
 	if err := json.Unmarshal(data, &metadata); err != nil {
-		return "", fmt.Errorf("decode npm metadata: %w", err)
+		return frontendPackageResolution{}, fmt.Errorf("decode npm metadata: %w", err)
 	}
 	if metadata.Name != packageName || metadata.Version != version {
-		return "", fmt.Errorf(
+		return frontendPackageResolution{}, fmt.Errorf(
 			"npm metadata identity mismatch: requested %s@%s, received %s@%s",
 			packageName,
 			version,
@@ -106,9 +116,40 @@ func resolveFrontendIntegrity(ctx context.Context, registryURL, packageName, ver
 		)
 	}
 	if !validFrontendIntegrity(metadata.Dist.Integrity) {
-		return "", errors.New("npm metadata dist.integrity must be one exact sha512 SRI")
+		return frontendPackageResolution{}, errors.New("npm metadata dist.integrity must be one exact sha512 SRI")
 	}
-	return metadata.Dist.Integrity, nil
+	tarball, err := validFrontendTarballURL(metadata.Dist.Tarball)
+	if err != nil {
+		return frontendPackageResolution{}, fmt.Errorf("npm metadata dist.tarball: %w", err)
+	}
+	return frontendPackageResolution{Integrity: metadata.Dist.Integrity, Tarball: tarball}, nil
+}
+
+func validFrontendTarballURL(value string) (string, error) {
+	if value == "" || value != strings.TrimSpace(value) || strings.ContainsAny(value, "\r\n\t") {
+		return "", errors.New("must be one absolute stable URL")
+	}
+	tarball, err := url.Parse(value)
+	if err != nil || !tarball.IsAbs() || tarball.Opaque != "" || tarball.Hostname() == "" || tarball.Path == "" {
+		return "", errors.New("must be one absolute stable URL")
+	}
+	if tarball.User != nil {
+		return "", errors.New("must not contain credentials")
+	}
+	if tarball.RawQuery != "" || tarball.Fragment != "" {
+		return "", errors.New("must not contain a query or fragment")
+	}
+	switch tarball.Scheme {
+	case "https":
+		return tarball.String(), nil
+	case "http":
+		if loopbackRegistryHost(tarball.Hostname()) {
+			return tarball.String(), nil
+		}
+		return "", errors.New("HTTP is allowed only for an explicit loopback fixture")
+	default:
+		return "", errors.New("must use HTTPS outside an explicit loopback fixture")
+	}
 }
 
 func frontendMetadataEndpoint(registryURL, packageName, version string) (string, error) {

--- a/internal/mss/blueprint/frontend_integrity_test.go
+++ b/internal/mss/blueprint/frontend_integrity_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 )
 
-func TestResolveFrontendIntegrityUsesExactLoopbackMetadata(t *testing.T) {
+func TestResolveFrontendPackageUsesExactLoopbackMetadata(t *testing.T) {
 	integrity := testFrontendIntegrity("candidate-tarball")
+	tarball := "https://packages.example.test/artifacts/admin-web-1.3.3-frozen.tgz"
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		if request.Method != http.MethodGet {
 			t.Errorf("metadata method = %s", request.Method)
@@ -24,31 +25,38 @@ func TestResolveFrontendIntegrityUsesExactLoopbackMetadata(t *testing.T) {
 			t.Error("metadata request unexpectedly forwarded credentials")
 		}
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(writer, `{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":%q}}`, integrity)
+		_, _ = fmt.Fprintf(
+			writer,
+			`{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":%q,"tarball":%q}}`,
+			integrity,
+			tarball,
+		)
 	}))
 	t.Cleanup(server.Close)
 
-	got, err := resolveFrontendIntegrity(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3")
+	got, err := resolveFrontendPackage(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3")
 	if err != nil {
-		t.Fatalf("resolveFrontendIntegrity() error = %v", err)
+		t.Fatalf("resolveFrontendPackage() error = %v", err)
 	}
-	if got != integrity {
-		t.Fatalf("resolveFrontendIntegrity() = %q, want %q", got, integrity)
+	if got.Integrity != integrity || got.Tarball != tarball {
+		t.Fatalf("resolveFrontendPackage() = %#v, want integrity %q and tarball %q", got, integrity, tarball)
 	}
 }
 
-func TestResolveFrontendIntegrityFailsClosed(t *testing.T) {
+func TestResolveFrontendPackageFailsClosed(t *testing.T) {
 	validIntegrity := testFrontendIntegrity("candidate-tarball")
+	validTarball := "https://packages.example.test/artifacts/admin-web-1.3.3-frozen.tgz"
 	for _, test := range []struct {
 		name     string
 		metadata string
 		status   int
 		want     string
 	}{
-		{name: "missing version", metadata: `{"name":"@mss-boot-io/admin-web","dist":{"integrity":"` + validIntegrity + `"}}`, status: http.StatusOK, want: "identity mismatch"},
-		{name: "wrong package", metadata: `{"name":"other","version":"1.3.3","dist":{"integrity":"` + validIntegrity + `"}}`, status: http.StatusOK, want: "identity mismatch"},
-		{name: "missing integrity", metadata: `{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{}}`, status: http.StatusOK, want: "sha512 SRI"},
-		{name: "invalid integrity", metadata: `{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":"sha512-short"}}`, status: http.StatusOK, want: "sha512 SRI"},
+		{name: "missing version", metadata: fmt.Sprintf(`{"name":"@mss-boot-io/admin-web","dist":{"integrity":%q,"tarball":%q}}`, validIntegrity, validTarball), status: http.StatusOK, want: "identity mismatch"},
+		{name: "wrong package", metadata: fmt.Sprintf(`{"name":"other","version":"1.3.3","dist":{"integrity":%q,"tarball":%q}}`, validIntegrity, validTarball), status: http.StatusOK, want: "identity mismatch"},
+		{name: "missing integrity", metadata: fmt.Sprintf(`{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"tarball":%q}}`, validTarball), status: http.StatusOK, want: "sha512 SRI"},
+		{name: "invalid integrity", metadata: fmt.Sprintf(`{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":"sha512-short","tarball":%q}}`, validTarball), status: http.StatusOK, want: "sha512 SRI"},
+		{name: "missing tarball", metadata: fmt.Sprintf(`{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":%q}}`, validIntegrity), status: http.StatusOK, want: "absolute stable URL"},
 		{name: "malformed metadata", metadata: `{`, status: http.StatusOK, want: "decode npm metadata"},
 		{name: "not found", metadata: `{}`, status: http.StatusNotFound, want: "HTTP 404"},
 	} {
@@ -58,50 +66,104 @@ func TestResolveFrontendIntegrityFailsClosed(t *testing.T) {
 				_, _ = writer.Write([]byte(test.metadata))
 			}))
 			t.Cleanup(server.Close)
-			_, err := resolveFrontendIntegrity(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3")
+			_, err := resolveFrontendPackage(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3")
 			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("resolveFrontendIntegrity() error = %v, want %q", err, test.want)
+				t.Fatalf("resolveFrontendPackage() error = %v, want %q", err, test.want)
 			}
 		})
 	}
 }
 
-func TestResolveFrontendIntegrityRejectsOversizedMetadata(t *testing.T) {
+func TestResolveFrontendPackageRejectsUnsafeTarballURLs(t *testing.T) {
+	integrity := testFrontendIntegrity("candidate-tarball")
+	for _, test := range []struct {
+		name    string
+		tarball string
+		want    string
+	}{
+		{name: "relative", tarball: "/artifacts/admin-web.tgz", want: "absolute stable URL"},
+		{name: "invalid scheme", tarball: "ftp://packages.example.test/admin-web.tgz", want: "must use HTTPS"},
+		{name: "non loopback HTTP", tarball: "http://packages.example.test/admin-web.tgz", want: "explicit loopback"},
+		{name: "userinfo", tarball: "https://token@packages.example.test/admin-web.tgz", want: "credentials"},
+		{name: "query", tarball: "https://packages.example.test/admin-web.tgz?token=secret", want: "query or fragment"},
+		{name: "fragment", tarball: "https://packages.example.test/admin-web.tgz#fragment", want: "query or fragment"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprintf(
+					writer,
+					`{"name":"@mss-boot-io/admin-web","version":"1.3.3","dist":{"integrity":%q,"tarball":%q}}`,
+					integrity,
+					test.tarball,
+				)
+			}))
+			t.Cleanup(server.Close)
+			_, err := resolveFrontendPackage(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("resolveFrontendPackage() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidFrontendTarballURLAllowsHTTPSAndExplicitLoopbackHTTP(t *testing.T) {
+	for _, value := range []string{
+		"https://packages.example.test/artifacts/admin-web.tgz",
+		"http://localhost:4873/artifacts/admin-web.tgz",
+		"http://127.0.0.1:4873/artifacts/admin-web.tgz",
+		"http://[::1]:4873/artifacts/admin-web.tgz",
+	} {
+		if got, err := validFrontendTarballURL(value); err != nil || got != value {
+			t.Fatalf("validFrontendTarballURL(%q) = %q, %v", value, got, err)
+		}
+	}
+}
+
+func TestResolveFrontendPackageRejectsOversizedMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		_, _ = writer.Write([]byte(strings.Repeat("x", maxFrontendMetadataBytes+1)))
 	}))
 	t.Cleanup(server.Close)
-	if _, err := resolveFrontendIntegrity(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "exceeds") {
+	if _, err := resolveFrontendPackage(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "exceeds") {
 		t.Fatalf("oversized metadata error = %v", err)
 	}
 }
 
-func TestResolveFrontendIntegrityRejectsRedirectAndNonLoopbackOverride(t *testing.T) {
+func TestResolveFrontendPackageRejectsRedirectAndNonLoopbackOverride(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		http.Redirect(writer, request, "https://registry.npmjs.org/", http.StatusFound)
 	}))
 	t.Cleanup(server.Close)
-	if _, err := resolveFrontendIntegrity(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "redirects are not allowed") {
+	if _, err := resolveFrontendPackage(context.Background(), server.URL, "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "redirects are not allowed") {
 		t.Fatalf("redirect error = %v", err)
 	}
-	if _, err := resolveFrontendIntegrity(context.Background(), "http://example.com", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "loopback") {
+	if _, err := resolveFrontendPackage(context.Background(), "http://example.com", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "loopback") {
 		t.Fatalf("non-loopback override error = %v", err)
 	}
-	if _, err := resolveFrontendIntegrity(context.Background(), "http://token@example.com", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "credentials") {
+	if _, err := resolveFrontendPackage(context.Background(), "http://token@example.com", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "credentials") {
 		t.Fatalf("credential-bearing override error = %v", err)
 	}
-	if _, err := resolveFrontendIntegrity(context.Background(), "http://127.0.0.1/registry", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "a path") {
+	if _, err := resolveFrontendPackage(context.Background(), "http://127.0.0.1/registry", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "a path") {
 		t.Fatalf("path-bearing override error = %v", err)
 	}
-	if _, err := resolveFrontendIntegrity(context.Background(), "http://127.0.0.1?token=secret", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "query") {
+	if _, err := resolveFrontendPackage(context.Background(), "http://127.0.0.1?token=secret", "@mss-boot-io/admin-web", "1.3.3"); err == nil || !strings.Contains(err.Error(), "query") {
 		t.Fatalf("query-bearing override error = %v", err)
 	}
 }
 
-func TestResolveFrontendIntegrityForSourceSkipsTemplatesWithoutToken(t *testing.T) {
-	got, err := resolveFrontendIntegrityForSource(context.Background(), "http://example.com", nil, []blueprintSourceFile{{Data: []byte("no frontend integrity token")}})
-	if err != nil || got != "" {
-		t.Fatalf("resolveFrontendIntegrityForSource() = %q, %v", got, err)
+func TestResolveFrontendPackageForSourceSkipsTemplatesWithoutTokens(t *testing.T) {
+	got, err := resolveFrontendPackageForSource(context.Background(), "http://example.com", nil, []blueprintSourceFile{{Data: []byte("no frontend package tokens")}})
+	if err != nil || got != (frontendPackageResolution{}) {
+		t.Fatalf("resolveFrontendPackageForSource() = %#v, %v", got, err)
+	}
+}
+
+func TestResolveFrontendPackageForSourceRequiresTarballAndIntegrityTogether(t *testing.T) {
+	for _, token := range []string{frontendIntegrityToken, frontendTarballToken} {
+		_, err := resolveFrontendPackageForSource(context.Background(), "http://example.com", nil, []blueprintSourceFile{{Data: []byte(token)}})
+		if err == nil || !strings.Contains(err.Error(), "tarball and integrity together") {
+			t.Fatalf("single frontend package token %q error = %v", token, err)
+		}
 	}
 }
 

--- a/internal/mss/blueprint/plan.go
+++ b/internal/mss/blueprint/plan.go
@@ -233,11 +233,11 @@ func buildDesired(ctx context.Context, root string, blueprint *Document, applica
 			Mode:       entry.Mode,
 		})
 	}
-	frontendIntegrity, err := resolveFrontendIntegrityForSource(ctx, frontendRegistryURL, blueprint, resolved)
+	frontendPackage, err := resolveFrontendPackageForSource(ctx, frontendRegistryURL, blueprint, resolved)
 	if err != nil {
 		return nil, Manifest{}, err
 	}
-	return buildDesiredFromSource(blueprint, source.BlueprintSHA, source.Identity, resolved, application, frontendIntegrity)
+	return buildDesiredFromSource(blueprint, source.BlueprintSHA, source.Identity, resolved, application, frontendPackage)
 }
 
 func buildDesiredFromSource(
@@ -246,7 +246,7 @@ func buildDesiredFromSource(
 	foundationIdentity FoundationIdentity,
 	sourceFiles []blueprintSourceFile,
 	application Application,
-	frontendIntegrity string,
+	frontendPackage frontendPackageResolution,
 ) (map[string]desiredFile, Manifest, error) {
 	files := make(map[string]desiredFile, len(sourceFiles)+2)
 	templatePrefix := ""
@@ -257,7 +257,7 @@ func buildDesiredFromSource(
 		relative := sourceFile.OutputPath
 		data := sourceFile.Data
 		if blueprint.Text(relative, data) {
-			data = transformText(data, blueprint, application, frontendIntegrity)
+			data = transformText(data, blueprint, application, frontendPackage)
 			if templatePrefix != "" && bytes.Contains(data, []byte("__MSS_")) {
 				return nil, Manifest{}, fmt.Errorf("application template %s contains an unresolved mss placeholder", sourceFile.SourcePath)
 			}
@@ -468,7 +468,7 @@ func buildDestinationPlan(
 	return plan, nil
 }
 
-func transformText(data []byte, blueprint *Document, application Application, frontendIntegrity string) []byte {
+func transformText(data []byte, blueprint *Document, application Application, frontendPackage frontendPackageResolution) []byte {
 	text := string(data)
 	const (
 		moduleSentinel     = "__MSS_BLUEPRINT_TARGET_MODULE__"
@@ -491,7 +491,8 @@ func transformText(data []byte, blueprint *Document, application Application, fr
 		{token: "__MSS_DISTRIBUTION_BACKEND_VERSION__", value: blueprint.Spec.Distribution.Backend.Version},
 		{token: "__MSS_DISTRIBUTION_FRONTEND_PACKAGE__", value: blueprint.Spec.Distribution.Frontend.Package},
 		{token: "__MSS_DISTRIBUTION_FRONTEND_VERSION__", value: blueprint.Spec.Distribution.Frontend.Version},
-		{token: frontendIntegrityToken, value: frontendIntegrity},
+		{token: frontendIntegrityToken, value: frontendPackage.Integrity},
+		{token: frontendTarballToken, value: frontendPackage.Tarball},
 	}
 	for _, replacement := range replacements {
 		text = strings.ReplaceAll(text, replacement.token, replacement.value)

--- a/internal/mss/blueprint/upgrade.go
+++ b/internal/mss/blueprint/upgrade.go
@@ -119,7 +119,7 @@ func UpgradeEmbedded(ctx context.Context, options UpgradeOptions) (UpgradePlan, 
 	if err != nil {
 		return UpgradePlan{}, err
 	}
-	frontendIntegrity, err := resolveFrontendIntegrityForSource(ctx, prepared.Options.FrontendRegistryURL, source.Blueprint, source.Files)
+	frontendPackage, err := resolveFrontendPackageForSource(ctx, prepared.Options.FrontendRegistryURL, source.Blueprint, source.Files)
 	if err != nil {
 		return UpgradePlan{}, err
 	}
@@ -129,7 +129,7 @@ func UpgradeEmbedded(ctx context.Context, options UpgradeOptions) (UpgradePlan, 
 		source.Identity,
 		source.Files,
 		prepared.Options.Application,
-		frontendIntegrity,
+		frontendPackage,
 	)
 	if err != nil {
 		return UpgradePlan{}, err

--- a/internal/mss/mcp/blueprint_tools_test.go
+++ b/internal/mss/mcp/blueprint_tools_test.go
@@ -279,9 +279,14 @@ func setMCPReleaseBuild(t *testing.T) {
 func mcpFrontendRegistry(t *testing.T) string {
 	t.Helper()
 	integrity := "sha512-" + strings.Repeat("A", 86) + "=="
-	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(writer, `{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q}}`, integrity)
+		_, _ = fmt.Fprintf(
+			writer,
+			`{"name":"@mss-boot-io/admin-web","version":"1.3.4","dist":{"integrity":%q,"tarball":%q}}`,
+			integrity,
+			"http://"+request.Host+"/artifacts/mcp-admin-web-1.3.4.tgz",
+		)
 	}))
 	t.Cleanup(server.Close)
 	return server.URL

--- a/templates/application/web/pnpm-lock.yaml
+++ b/templates/application/web/pnpm-lock.yaml
@@ -1010,7 +1010,7 @@ packages:
     resolution: {integrity: sha512-zd343RO7/R7Xjh5ym5KdnYQ70z4LBmMxWsa44FS0nyNv04sOq6V1eZSCGKbEhbfqqhbS5Wfj8OzJyedeVvV/OQ==}
 
   '@mss-boot-io/admin-web@__MSS_DISTRIBUTION_FRONTEND_VERSION__':
-    resolution: {integrity: __MSS_DISTRIBUTION_FRONTEND_INTEGRITY__}
+    resolution: {tarball: __MSS_DISTRIBUTION_FRONTEND_TARBALL__, integrity: __MSS_DISTRIBUTION_FRONTEND_INTEGRITY__}
     engines: {node: '>=24.0.0 <25', pnpm: 10.34.5}
     hasBin: true
 

--- a/tools/compatibility/test-standalone-mss-consumer.sh
+++ b/tools/compatibility/test-standalone-mss-consumer.sh
@@ -361,7 +361,9 @@ if [[ "${use_public_packages}" = true ]]; then
     --arg commit "${release_commit}" \
     '.name == "@mss-boot-io/admin-web" and
      .version == $version and .gitHead == $commit and
-     (.dist.integrity | type == "string" and startswith("sha512-"))' \
+     (.dist.integrity | type == "string" and startswith("sha512-")) and
+     (.dist.tarball | type == "string" and startswith("https://") and
+      (contains("?") or contains("#")) == false)' \
     "${public_package_metadata}" >/dev/null || {
     echo "published GitHub Packages Admin Web candidate has the wrong identity or provenance" >&2
     exit 1
@@ -449,7 +451,13 @@ fi
 
 registry_ready="${work_dir}/registry-url"
 registry_log="${work_dir}/registry.log"
-python3 - "${admin_web_tarball}" "${release_version#v}" "${release_commit}" "${registry_ready}" <<'PY' >"${registry_log}" 2>&1 &
+fixture_tarball_path="/artifacts/frozen-admin-web-${release_version#v}.tgz"
+pnpm_fallback_tarball_path="/@mss-boot-io/admin-web/-/admin-web-${release_version#v}.tgz"
+[[ "${fixture_tarball_path}" != "${pnpm_fallback_tarball_path}" ]] || {
+  echo "temporary registry tarball path must differ from pnpm's generic registry fallback" >&2
+  exit 1
+}
+python3 - "${admin_web_tarball}" "${release_version#v}" "${release_commit}" "${registry_ready}" "${fixture_tarball_path}" <<'PY' >"${registry_log}" 2>&1 &
 from hashlib import sha512
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import base64
@@ -462,10 +470,10 @@ tarball = Path(sys.argv[1]).resolve()
 version = sys.argv[2]
 commit = sys.argv[3]
 ready = Path(sys.argv[4]).resolve()
+tarball_path = sys.argv[5]
 package_name = '@mss-boot-io/admin-web'
 integrity = 'sha512-' + base64.b64encode(sha512(tarball.read_bytes()).digest()).decode('ascii')
 metadata_path = f'/{package_name}/{version}'
-tarball_path = f'/{package_name}/-/admin-web-{version}.tgz'
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -583,6 +591,22 @@ if grep -Eq 'go run ./cmd/mss|--foundation|__MSS_' "${host_root}/.github/workflo
 fi
 grep -Fq 'admin: go run ./cmd/server server' "${host_root}/.mss/project.yaml"
 grep -Fq 'command: [go, run, ./cmd/server, server]' "${host_root}/.mss/dev.yaml"
+grep -Fq "tarball: ${registry_url}${fixture_tarball_path}" "${host_root}/web/pnpm-lock.yaml" || {
+  echo "generated frontend lock does not pin the metadata dist.tarball URL" >&2
+  exit 1
+}
+grep -Fq "integrity: ${computed_admin_web_integrity}" "${host_root}/web/pnpm-lock.yaml" || {
+  echo "generated frontend lock does not pin the metadata dist.integrity" >&2
+  exit 1
+}
+if grep -Fq "${registry_url}${pnpm_fallback_tarball_path}" "${host_root}/web/pnpm-lock.yaml"; then
+  echo "generated frontend lock fell back to pnpm's inferred tarball URL" >&2
+  exit 1
+fi
+if grep -Eq 'NODE_AUTH_TOKEN|_authToken' "${host_root}/web/.npmrc" "${host_root}/web/pnpm-lock.yaml"; then
+  echo "generated frontend files contain a registry credential reference" >&2
+  exit 1
+fi
 
 tree_digest() {
   python3 - "$1" <<'PY'

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -150,6 +150,26 @@ class WorkflowGovernanceTest(unittest.TestCase):
             with self.subTest(required=required):
                 self.assertIn(required, script)
 
+    def test_foundation_compatibility_registry_serves_exact_tarball_metadata(self):
+        workflow = self.workflows["foundation-compatibility.yml"]
+        steps = workflow["jobs"]["downstream-generation-and-upgrade"]["steps"]
+        registry = next(
+            step
+            for step in steps
+            if step.get("name") == "Start temporary Admin Web metadata registry"
+        )
+        script = registry["run"]
+        for required in (
+            "tarball = f'foundation-compatibility-admin-web-{version}'.encode('utf-8')",
+            "sha512(tarball).digest()",
+            "tarball_path = f'/artifacts/foundation-compatibility-admin-web-{version}.tgz'",
+            "'tarball': f'http://127.0.0.1:{self.server.server_port}{tarball_path}'",
+            "if path == tarball_path:",
+            "self.wfile.write(tarball)",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, script)
+
     def test_scorecard_does_not_run_on_every_main_push(self):
         triggers = self.workflows["scorecard.yml"]["on"]
         self.assertEqual(


### PR DESCRIPTION
## Summary

- preserve and validate npm metadata `dist.tarball` together with `dist.integrity`
- embed the exact tarball URL in generated Thin Host pnpm locks
- make the compatibility registry use a non-fallback artifact path so pnpm URL inference can no longer mask this regression
- fail closed on unsafe tarball URLs and credential-bearing metadata

## Root cause

The Blueprint generator retained only `dist.integrity`. With no tarball in the frozen lock, pnpm inferred a generic scoped-registry URL that GitHub Packages redirects to a nonexistent unscoped npmjs tarball.

## Validation

- `GOWORK=off go test ./internal/mss/...`
- `shellcheck tools/compatibility/test-standalone-mss-consumer.sh`
- `bash tools/compatibility/test-standalone-mss-consumer.sh --lifecycle --upgrade`
- external lifecycle passed at `acdf1c396c0208405a13a27d6453e445ab279c56`

## Docs impact

No user-facing command or supported workflow changes. The generated lock now records the registry-provided immutable tarball URL; existing package-first documentation remains accurate.

## Security impact

Tarball metadata now fails closed unless it is a credential-free stable HTTPS URL, with HTTP allowed only for explicit loopback test fixtures. Query strings, fragments, userinfo, relative URLs, and non-HTTP(S) schemes are rejected. No token or auth reference is written to generated files.

## Release and compatibility impact

This PR does not change a version or move any published v1.3.4 ref. The existing v1.3.4 public artifacts remain immutable; release recovery requires a separate coordinated-version decision. Existing Thin Hosts are not mutated until they explicitly run a future released generator or upgrade.
