### PR TITLE
fix(release): provision e2e secret in readiness

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -201,6 +201,14 @@ jobs:
         working-directory: web/antd-v6
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Create ephemeral browser administrator secret
+        if: ${{ inputs.phase == 'feature-freeze' || inputs.phase == 'pre-framework' || inputs.phase == 'pre-root' }}
+        run: |
+          set -euo pipefail
+          password="MssE2E-A1-$(openssl rand -hex 24)"
+          echo "::add-mask::${password}"
+          echo "MSS_E2E_PASSWORD=${password}" >> "${GITHUB_ENV}"
+
       - name: Install documentation dependencies
         if: ${{ inputs.phase == 'feature-freeze' }}
         run: corepack pnpm@9.15.9 --dir docs install --frozen-lockfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ artifact.
 - Preserve the exact Admin Web package tarball URL in generated Thin Host
   lockfiles, and keep the downstream compatibility registry fixture aligned
   with that metadata contract so frozen installs never infer a registry path.
+- Provision a masked, job-scoped browser administrator password before Release
+  Readiness executes qualifying phase commands, so the canonical browser suite
+  retains its required isolated credential without storing a reusable secret.
 
 ### Changed
 

--- a/tools/release/test_release_readiness_workflow.py
+++ b/tools/release/test_release_readiness_workflow.py
@@ -98,6 +98,21 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             self.steps.index(playwright_install),
             self.steps.index(phase),
         )
+        browser_secret = self.step("Create ephemeral browser administrator secret")
+        self.assertEqual(browser_secret["if"], RUNTIME_PHASE_CONDITION)
+        self.assertIn(
+            'password="MssE2E-A1-$(openssl rand -hex 24)"',
+            browser_secret["run"],
+        )
+        self.assertIn('echo "::add-mask::${password}"', browser_secret["run"])
+        self.assertIn(
+            'echo "MSS_E2E_PASSWORD=${password}" >> "${GITHUB_ENV}"',
+            browser_secret["run"],
+        )
+        self.assertLess(
+            self.steps.index(browser_secret),
+            self.steps.index(phase),
+        )
         self.assertEqual(self.step("Setup pnpm")["with"]["version"], "10.34.5")
 
     def test_publication_authority_phases_execute_and_only_checkpoint_plans(self):
@@ -106,6 +121,7 @@ class ReleaseReadinessWorkflowTest(unittest.TestCase):
             "Setup Node",
             "Install frontend dependencies",
             "Install Playwright Chromium",
+            "Create ephemeral browser administrator secret",
         ):
             self.assertEqual(self.step(step_name)["if"], RUNTIME_PHASE_CONDITION)
 


### PR DESCRIPTION
## Summary

- generate a random, job-scoped browser administrator password before Release Readiness executes phase commands
- mask the password and expose it only through `GITHUB_ENV` for the qualifying job
- add a workflow regression test that requires the secret step and its ordering before phase execution

## Failure evidence

Feature-freeze run https://github.com/mss-boot-io/mss-boot-admin/actions/runs/32973145782 failed on `make web-v6-qualify` because Playwright's isolated web server correctly rejected a missing `MSS_E2E_PASSWORD`. The other eight phase commands passed. The failed run produced no acceptable readiness attestation and does not authorize publication.

## Validation and tests

- reproduced the missing-password failure locally with `pnpm test:e2e`
- `python3 tools/release/test_release_readiness_workflow.py` — 7 passed
- `python3 -m unittest discover -s tools/release -p 'test_*.py'` — 163 passed
- Playwright with a generated ephemeral password — 17 passed, 1 contractually skipped
- `GOWORK=off go run ./cmd/mss verify --changed` — passed
- `python3 tools/docs/check_current_docs.py` — passed
- `git diff --check` — passed

## Documentation impact

The v1.3.5 changelog now records the job-scoped Release Readiness credential gate. No adopter command, public API, or package import path changes.

## Security and release impact

The password is generated with OpenSSL for one job, masked before export, never stored in repository secrets, artifacts, or source, and the E2E fail-closed behavior remains unchanged. After merge, `v1.3.5` must be frozen again from the new exact merged-main commit; no existing tag or release is changed. Compatibility and rollback behavior are unchanged because this affects qualification orchestration only.
