### PR TITLE
fix(ci): stop release tags from repeating tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*.*.*'
     paths-ignore:
       - 'docs/**'
       - 'web/**'

--- a/.github/workflows/mss-boot-ci.yml
+++ b/.github/workflows/mss-boot-ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'mss-boot/v*.*.*'
     paths:
       - 'mss-boot/**'
       - '.mss/coverage.json'

--- a/docs/adr/2026-08-04-component-scoped-ci.md
+++ b/docs/adr/2026-08-04-component-scoped-ci.md
@@ -54,7 +54,7 @@ Additional rules:
 
 ## Compatibility
 
-The workflow file `.github/workflows/ci.yml` keeps the workflow name `CI` and exposes a final job named `admin-ci`. The `main` branch rule requires that exact context, so the workflow is intentionally unfiltered for pull requests. Push and tag events remain path-scoped where no pull-request merge gate depends on them.
+The workflow file `.github/workflows/ci.yml` keeps the workflow name `CI` and exposes a final job named `admin-ci`. The `main` branch rule requires that exact context, so the workflow is intentionally unfiltered for pull requests. Main-branch pushes remain path-scoped where no pull-request merge gate depends on them. Release tags are owned only by their publication workflows so a tag cannot repeat the component test suites already qualified by the exact successful preview.
 
 The frontend workflow similarly keeps `Frontend CI / build` as an aggregate over quality and compilation. New framework and container checks can be made required after one successful pull-request run establishes their exact check names.
 

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -121,6 +121,23 @@ class WorkflowGovernanceTest(unittest.TestCase):
             self.workflows["ci.yml"]["jobs"]["build"]["name"], "admin-ci"
         )
 
+    def test_release_tags_do_not_retrigger_component_ci(self):
+        for workflow_name in ("ci.yml", "mss-boot-ci.yml"):
+            workflow = self.workflows[workflow_name]
+            self.assertEqual(workflow["on"]["push"]["branches"], ["main"])
+            self.assertNotIn("tags", workflow["on"]["push"])
+            self.assertEqual(
+                workflow["on"]["pull_request"]["branches"], ["main"]
+            )
+        self.assertEqual(
+            self.workflows["release.yml"]["on"]["push"]["tags"],
+            ["v*.*.*"],
+        )
+        self.assertEqual(
+            self.workflows["framework-release.yml"]["on"]["push"]["tags"],
+            ["mss-boot/v*.*.*"],
+        )
+
     def test_macos_portable_tests_use_the_real_runner_temp_directory(self):
         job = self.workflows["agent-native-ci.yml"]["jobs"][
             "cross-platform-agent-tools"


### PR DESCRIPTION
Formal Root and Framework tags already reuse exact successful preview evidence. Remove their duplicate component-CI tag triggers so stable publication remains lightweight. Main-branch and pull-request validation are unchanged, and governance tests lock the trigger boundary.

Tests: 25 workflow YAML files parsed; 56 workflow and release-policy tests passed.

Docs: the component-scoped CI ADR now records that release tags belong only to publication workflows.

Security: no permission, secret, actor, or release-governance authority changes.

Release and compatibility: no version or tag is created or changed; preview qualification remains the mandatory evidence source, while formal tags stop repeating component test suites. No migration or rollback action is required.