### PR TITLE
fix(release): recognize organization docs secret

### DIFF
--- a/.agents/skills/mss-release/SKILL.md
+++ b/.agents/skills/mss-release/SKILL.md
@@ -163,7 +163,7 @@ bash tools/release/verify_remote_release_governance.sh \
   > ".mss/reports/remote-release-governance-${VERSION}.json"
 ```
 
-The verifier requires exactly one consolidated controlled-creation ruleset, the no-bypass v1.3.5 stopped-tag creation ruleset, and the no-bypass immutable tag ruleset. It also requires exact tag policies, no administrator bypass, and no required reviewers on the active publishing environments, while confirming required environment secret names without reading their values. The retired publishing environments must remain blocked so an old workflow cannot regain publication authority.
+The verifier requires exactly one consolidated controlled-creation ruleset, the no-bypass v1.3.5 stopped-tag creation ruleset, and the no-bypass immutable tag ruleset. It also requires exact tag policies, no administrator bypass, and no required reviewers on the active publishing environments. The Docs credential must be the organization-managed `CF_API_TOKEN` shared with this repository, with no repository or environment override; the environment-bound Docs workflow checks effective availability without printing its value before deployment. The retired publishing environments must remain blocked so an old workflow cannot regain publication authority.
 
 ### 7. Push the Root tag; publish Docs later
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -256,10 +256,20 @@ jobs:
             '.application == "mss-boot-docs" and .version == $version and .commit == $commit' \
             docs/dist/release.json >/dev/null
 
+      - name: Require organization-managed Cloudflare credential
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CF_API_TOKEN:-}" ]]; then
+            echo 'CF_API_TOKEN must be shared with this repository from organization Actions secrets' >&2
+            exit 1
+          fi
+
       - name: Deploy production documentation
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
-          apiToken: ${{ secrets.cf_api_token }}
+          apiToken: ${{ secrets.CF_API_TOKEN }}
           packageManager: npm
           wranglerVersion: '4'
           workingDirectory: docs

--- a/.mss/commands.yaml
+++ b/.mss/commands.yaml
@@ -247,7 +247,7 @@ spec:
 
     remote-release-governance-verify:
       command: bash tools/release/verify_remote_release_governance.sh --repository <owner/repository> --release-actor-login lwnmengjing
-      description: As any authenticated repository administrator, emit sanitized metadata proving that Root, component, and Docs tag creation belongs only to lwnmengjing, stopped v1.3.5 refs have a creation-only no-bypass freeze, every release tag remains immutable, active publishing environments have exact tag policies with no reviewer pause or administrator bypass, and retired environments allow no ref; required environment secret names are checked without reading secret values.
+      description: As any authenticated repository administrator, emit sanitized metadata proving that Root, component, and Docs tag creation belongs only to lwnmengjing, stopped v1.3.5 refs have a creation-only no-bypass freeze, every release tag remains immutable, active publishing environments have exact tag policies with no reviewer pause or administrator bypass, and retired environments allow no ref; the organization-managed Docs credential must be available to this repository without repository or environment overrides, and no secret value is read.
       outputFormats: [json]
       category: release
       idempotent: true

--- a/.mss/features/foundation-v1-3-5-release-recovery.yaml
+++ b/.mss/features/foundation-v1-3-5-release-recovery.yaml
@@ -103,7 +103,7 @@ spec:
       rules:
         - Every release preview and component, Root, npm, or Docs tag workflow requires both GITHUB_ACTOR and GITHUB_TRIGGERING_ACTOR to equal lwnmengjing before checkout, secrets, or writes.
         - One controlled-creation ruleset covers component, Root, and Docs tag namespaces and contains exactly lwnmengjing with no second user, Team, App, Integration, DeployKey, or administrator authority.
-        - New release-auto, release-v6-auto, npm-auto, and prod environments retain exact tag policies and required secrets but have no required reviewers; retired release and release-v6 environments allow no ref and cannot revive old workflows.
+        - New release-auto, release-v6-auto, npm-auto, and prod environments retain exact tag policies but have no required reviewers; Docs consumes the organization-managed CF_API_TOKEN shared with this repository, repository and environment overrides remain absent, and the environment-bound workflow checks effective availability before deployment. Retired release and release-v6 environments allow no ref and cannot revive old workflows.
         - The obsolete Root promotion workflow, write-enabled DeployKey, promotion secret, promotion environment, and root-only creation ruleset are absent.
     - id: publish-truthful-status-documentation
       title: Disable incomplete adopter onboarding

--- a/tools/release/test_remote_release_governance.py
+++ b/tools/release/test_remote_release_governance.py
@@ -88,16 +88,30 @@ import json
 import os
 import sys
 
-if len(sys.argv) != 3 or sys.argv[1] != "api":
-    print("fake gh supports only: gh api ENDPOINT", file=sys.stderr)
+if len(sys.argv) < 3 or sys.argv[1] != "api":
+    print("fake gh supports only: gh api [FLAGS] ENDPOINT", file=sys.stderr)
     raise SystemExit(2)
 with open(os.environ["FAKE_GH_STATE"], encoding="utf-8") as handle:
     responses = json.load(handle)
-endpoint = sys.argv[2]
+arguments = sys.argv[2:]
+endpoints = [argument for argument in arguments if not argument.startswith("-")]
+if len(endpoints) != 1:
+    print("fake gh requires exactly one API endpoint", file=sys.stderr)
+    raise SystemExit(2)
+endpoint = endpoints[0]
 if endpoint not in responses:
     print(f"unexpected gh api endpoint: {endpoint}", file=sys.stderr)
     raise SystemExit(3)
-json.dump(responses[endpoint], sys.stdout)
+response = responses[endpoint]
+if isinstance(response, dict) and "__pages__" in response:
+    if "--paginate" not in arguments:
+        print("multi-page fake response requires --paginate", file=sys.stderr)
+        raise SystemExit(4)
+    for page in response["__pages__"]:
+        json.dump(page, sys.stdout)
+        sys.stdout.write("\\n")
+else:
+    json.dump(response, sys.stdout)
 """,
             encoding="utf-8",
         )
@@ -257,6 +271,8 @@ json.dump(responses[endpoint], sys.stdout)
         self.assertIn("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$", self.content)
         self.assertNotRegex(self.content, re.compile(r"gh auth token|Authorization:"))
         self.assertNotRegex(self.content, re.compile(r"secrets\[[^]]+\]\.value"))
+        self.assertIn("gh api --paginate", self.content)
+        self.assertIn("jq -s -e", self.content)
 
     def test_valid_simplified_governance_contract_is_reported(self):
         result = self.run_script()
@@ -377,6 +393,31 @@ json.dump(responses[endpoint], sys.stdout)
         state[f"/repos/{REPOSITORY}/actions/secrets?per_page=100"] = named_items(
             "secrets", ["CF_API_TOKEN"]
         )
+        self.assert_rejected(
+            state,
+            "repository-level CF_API_TOKEN would override the organization secret",
+        )
+
+    def test_docs_secret_checks_all_repository_and_organization_pages(self):
+        state = copy.deepcopy(self.state)
+        state[
+            f"/repos/{REPOSITORY}/actions/organization-secrets?per_page=100"
+        ] = {
+            "__pages__": [
+                named_items("secrets", ["UNRELATED_ORG_SECRET"]),
+                named_items("secrets", ["CF_API_TOKEN"]),
+            ]
+        }
+        result = self.run_script(state)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+        state = copy.deepcopy(self.state)
+        state[f"/repos/{REPOSITORY}/actions/secrets?per_page=100"] = {
+            "__pages__": [
+                named_items("secrets", ["UNRELATED_REPOSITORY_SECRET"]),
+                named_items("secrets", ["CF_API_TOKEN"]),
+            ]
+        }
         self.assert_rejected(
             state,
             "repository-level CF_API_TOKEN would override the organization secret",

--- a/tools/release/test_remote_release_governance.py
+++ b/tools/release/test_remote_release_governance.py
@@ -154,6 +154,12 @@ json.dump(responses[endpoint], sys.stdout)
             f"/repos/{REPOSITORY}/actions/variables?per_page=100": named_items(
                 "variables", []
             ),
+            f"/repos/{REPOSITORY}/actions/secrets?per_page=100": named_items(
+                "secrets", []
+            ),
+            f"/repos/{REPOSITORY}/actions/organization-secrets?per_page=100": named_items(
+                "secrets", ["CF_API_TOKEN", "UNRELATED_ORG_SECRET"]
+            ),
             f"/repos/{REPOSITORY}/rulesets?includes_parents=true&per_page=100": ruleset_summaries,
             f"/repos/{REPOSITORY}/rulesets/101?includes_parents=true": {
                 **common_ruleset,
@@ -205,10 +211,9 @@ json.dump(responses[endpoint], sys.stdout)
             state[
                 f"/repositories/{REPOSITORY_ID}/environments/{name}/variables?per_page=100"
             ] = named_items("variables", [])
-            secret_names = ["cf_api_token"] if name == "prod" else []
             state[
                 f"/repositories/{REPOSITORY_ID}/environments/{name}/secrets?per_page=100"
-            ] = named_items("secrets", secret_names)
+            ] = named_items("secrets", [])
         return state
 
     def run_script(self, state=None):
@@ -285,7 +290,16 @@ json.dump(responses[endpoint], sys.stdout)
                 "releaseAuto": [],
                 "releaseV6Auto": [],
                 "npmAuto": [],
-                "prod": ["cf_api_token"],
+                "prod": [],
+            },
+        )
+        self.assertEqual(
+            report["docsCredential"],
+            {
+                "name": "CF_API_TOKEN",
+                "source": "organization",
+                "repositoryOverride": False,
+                "environmentOverride": False,
             },
         )
 
@@ -337,14 +351,8 @@ json.dump(responses[endpoint], sys.stdout)
                     f"{name} environment deployment branch or tag policies are not exact",
                 )
 
-    def test_environment_secret_name_sets_are_exact(self):
-        for name in (
-            "release",
-            "release-v6",
-            "release-auto",
-            "release-v6-auto",
-            "npm-auto",
-        ):
+    def test_environment_secret_name_sets_are_exact_and_docs_secret_is_org_scoped(self):
+        for name in ALL_ENVIRONMENTS:
             with self.subTest(environment=name):
                 state = copy.deepcopy(self.state)
                 endpoint = (
@@ -358,9 +366,21 @@ json.dump(responses[endpoint], sys.stdout)
 
         state = copy.deepcopy(self.state)
         state[
-            f"/repositories/{REPOSITORY_ID}/environments/prod/secrets?per_page=100"
-        ] = named_items("secrets", [])
-        self.assert_rejected(state, "prod environment secret names are not exact")
+            f"/repos/{REPOSITORY}/actions/organization-secrets?per_page=100"
+        ] = named_items("secrets", ["UNRELATED_ORG_SECRET"])
+        self.assert_rejected(
+            state,
+            "CF_API_TOKEN must be available to this repository from organization Actions secrets",
+        )
+
+        state = copy.deepcopy(self.state)
+        state[f"/repos/{REPOSITORY}/actions/secrets?per_page=100"] = named_items(
+            "secrets", ["CF_API_TOKEN"]
+        )
+        self.assert_rejected(
+            state,
+            "repository-level CF_API_TOKEN would override the organization secret",
+        )
 
     def test_readiness_run_variable_is_absent_at_repository_and_every_environment(self):
         self.assertIn(

--- a/tools/release/test_workflow_governance.py
+++ b/tools/release/test_workflow_governance.py
@@ -1350,6 +1350,32 @@ exit 66
             ),
         )
 
+        deployment = workflow["jobs"]["deployment"]
+        self.assertEqual(deployment["environment"], "prod")
+        deployment_steps = deployment["steps"]
+        credential = next(
+            step
+            for step in deployment_steps
+            if step.get("name")
+            == "Require organization-managed Cloudflare credential"
+        )
+        self.assertEqual(
+            credential["env"],
+            {"CF_API_TOKEN": "${{ secrets.CF_API_TOKEN }}"},
+        )
+        self.assertIn('[[ -z "${CF_API_TOKEN:-}" ]]', credential["run"])
+        publish = next(
+            step
+            for step in deployment_steps
+            if step.get("name") == "Deploy production documentation"
+        )
+        self.assertEqual(
+            publish["with"]["apiToken"], "${{ secrets.CF_API_TOKEN }}"
+        )
+        self.assertLess(
+            deployment_steps.index(credential), deployment_steps.index(publish)
+        )
+
     def test_root_tag_automatically_drives_root_image_and_npm_without_docs(self):
         root = self.workflows["release.yml"]
         metadata = next(

--- a/tools/release/verify_remote_release_governance.sh
+++ b/tools/release/verify_remote_release_governance.sh
@@ -52,17 +52,17 @@ jq -e '.permissions.admin == true' <<< "${repository_json}" >/dev/null || {
 }
 repository_id="$(jq -er '.id' <<< "${repository_json}")"
 
-repository_secrets="$(gh api "/repos/${repository}/actions/secrets?per_page=100")"
-if jq -e '
-  any(.secrets[]; (.name | ascii_upcase) == "CF_API_TOKEN")
+repository_secrets="$(gh api --paginate "/repos/${repository}/actions/secrets?per_page=100")"
+if jq -s -e '
+  any(.[]; any(.secrets[]; (.name | ascii_upcase) == "CF_API_TOKEN"))
 ' <<< "${repository_secrets}" >/dev/null; then
   echo 'repository-level CF_API_TOKEN would override the organization secret' >&2
   exit 1
 fi
 
-organization_secrets="$(gh api "/repos/${repository}/actions/organization-secrets?per_page=100")"
-jq -e '
-  ([.secrets[] | select((.name | ascii_upcase) == "CF_API_TOKEN")] | length) == 1
+organization_secrets="$(gh api --paginate "/repos/${repository}/actions/organization-secrets?per_page=100")"
+jq -s -e '
+  ([.[] | .secrets[] | select((.name | ascii_upcase) == "CF_API_TOKEN")] | length) == 1
 ' <<< "${organization_secrets}" >/dev/null || {
   echo 'CF_API_TOKEN must be available to this repository from organization Actions secrets' >&2
   exit 1

--- a/tools/release/verify_remote_release_governance.sh
+++ b/tools/release/verify_remote_release_governance.sh
@@ -52,6 +52,22 @@ jq -e '.permissions.admin == true' <<< "${repository_json}" >/dev/null || {
 }
 repository_id="$(jq -er '.id' <<< "${repository_json}")"
 
+repository_secrets="$(gh api "/repos/${repository}/actions/secrets?per_page=100")"
+if jq -e '
+  any(.secrets[]; (.name | ascii_upcase) == "CF_API_TOKEN")
+' <<< "${repository_secrets}" >/dev/null; then
+  echo 'repository-level CF_API_TOKEN would override the organization secret' >&2
+  exit 1
+fi
+
+organization_secrets="$(gh api "/repos/${repository}/actions/organization-secrets?per_page=100")"
+jq -e '
+  ([.secrets[] | select((.name | ascii_upcase) == "CF_API_TOKEN")] | length) == 1
+' <<< "${organization_secrets}" >/dev/null || {
+  echo 'CF_API_TOKEN must be available to this repository from organization Actions secrets' >&2
+  exit 1
+}
+
 deploy_keys="$(gh api "/repos/${repository}/keys?per_page=100")"
 if jq -e 'any(.[]; .title == "mss-root-tag-promotion")' \
   <<< "${deploy_keys}" >/dev/null; then
@@ -308,7 +324,7 @@ verify_environment_secrets release-v6
 verify_environment_secrets release-auto
 verify_environment_secrets release-v6-auto
 verify_environment_secrets npm-auto
-verify_environment_secrets prod cf_api_token
+verify_environment_secrets prod
 
 jq -n \
   --arg repository "${repository}" \
@@ -345,6 +361,12 @@ jq -n \
       releaseAuto: [],
       releaseV6Auto: [],
       npmAuto: [],
-      prod: ["cf_api_token"]
+      prod: []
+    },
+    docsCredential: {
+      name: "CF_API_TOKEN",
+      source: "organization",
+      repositoryOverride: false,
+      environmentOverride: false
     }
   }'


### PR DESCRIPTION
The Docs pipeline already receives CF_API_TOKEN from organization Actions secrets. Update release governance to verify the organization secret is shared with this repository, reject repository/environment overrides, and check effective availability before Wrangler deployment.

Tests: 148 release-tool tests passed; the changed MSS Feature validates; mss verify --changed passed; the corrected live governance verifier returned success.

Docs: release skill and machine-readable command/Feature guidance now describe the organization-managed credential source.

Security: no secret value is read or printed. The verifier checks names and precedence only; the Docs job performs a non-empty runtime check before deployment.

Release and compatibility: no version or tag is created or changed. Existing actor, immutable-tag, environment, preview, and pipeline publication rules remain unchanged. No migration or rollback action is required.