### PR TITLE
fix(release): allow v1.3.6 Root preview to start

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,11 @@ jobs:
   container-preview:
     needs: metadata
     if: needs.metadata.outputs.publish != 'true'
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+      pull-requests: read
     uses: ./.github/workflows/container.yml
     with:
       version: ${{ needs.metadata.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ commit. This entry does not authorize installation or mixed-version adoption.
 
 ### Fixed
 
+- Allow the Root candidate to call the reusable container workflow with its
+  exact nested permission ceiling. GitHub can now start the candidate graph,
+  while the version-only preview remains non-publishing and its container build
+  keeps the called workflow's read-only permissions.
 - Make a manual Root Release dispatch a candidate-only preview and make an
   exact formal Root tag push publish automatically, eliminating the second
   publish dispatch, manually selected run IDs, evidence URL, and protected

--- a/tools/release/test_root_release_workflow.py
+++ b/tools/release/test_root_release_workflow.py
@@ -8,6 +8,9 @@ import yaml
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "release.yml"
+CONTAINER_WORKFLOW_PATH = (
+    REPOSITORY_ROOT / ".github" / "workflows" / "container.yml"
+)
 GITHUB_EXPRESSION = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
 
 
@@ -140,6 +143,21 @@ class RootReleaseWorkflowTest(unittest.TestCase):
         self.assertNotIn("refusing to mutate", script)
         for forbidden in ("gh run watch", "gh workflow run", "sleep "):
             self.assertNotIn(forbidden, script)
+
+    def test_container_preview_allows_only_the_nested_permission_ceiling(self):
+        container_workflow = yaml.load(
+            CONTAINER_WORKFLOW_PATH.read_text(encoding="utf-8"),
+            Loader=yaml.BaseLoader,
+        )
+        preview = self.jobs["container-preview"]
+        self.assertEqual(
+            preview["permissions"],
+            container_workflow["jobs"]["publish"]["permissions"],
+        )
+        self.assertEqual(
+            preview["if"], "needs.metadata.outputs.publish != 'true'"
+        )
+        self.assertEqual(set(preview["with"]), {"version"})
 
     def test_root_requires_only_exact_public_component_releases(self):
         evidence = self.step(


### PR DESCRIPTION
## Root cause

The unique v1.3.6 Root Candidate Preview run #67 stopped with startup_failure before GitHub created any job. The run annotation showed that release.yml called container.yml without allowing the nested publish job permission ceiling (packages: write and pull-requests: read).

## Fix

- Grant only the container-preview reusable-workflow call the exact nested permission ceiling.
- Keep the preview condition and version-only input unchanged, so workflow_dispatch remains non-publishing.
- Add a contract test that compares the caller permission set with the nested container publish job permission set, preventing both missing permissions and accidental expansion.

## Tests

- 13 Root release workflow tests passed.
- 37 workflow-governance and container-workflow tests passed.
- mss verify --changed passed with Go 1.26.6 and Node 24.
- A reusable-workflow permission audit reports no remaining missing scope.

## Documentation impact

The v1.3.6 Fixed section in CHANGELOG.md records the startup failure, the exact permission-ceiling repair, and the unchanged non-publishing preview boundary.

## Security impact

The permission ceiling is scoped only to the reusable container-preview call. The called preview build retains the container workflow read-only permissions; packages: write belongs only to the nested publish job, whose tag-push condition is false during preview. No credential, secret, public write path, or authorization bypass is added.

## Release, compatibility, and rollback impact

The failed run created no jobs, artifacts, tags, packages, images, or GitHub Releases. After this PR merges, v1.3.6 qualification must freeze the new merged-main commit and run one new exact preview for that commit. The failed old-SHA run is not reusable release evidence. This workflow-only repair has no migration or runtime compatibility impact; rollback is a normal revert through a follow-up PR before publication.